### PR TITLE
refactor(discover): delegate discover_devices to shared awto-serial discover()

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/awto-mcp-serial"]
 	path = vendor/awto-mcp-serial
-	url = https://github.com/awto-au/awto-mcp-serial.git
+	url = https://github.com/awtoau/awto-serial.git

--- a/USB_TESTING.md
+++ b/USB_TESTING.md
@@ -172,6 +172,12 @@ If daemon connects but queries hang:
 
 ## Concurrency: one thread per port (proven)
 
+> **Canonical home:** the one-thread-per-port rule now lives in the shared
+> awto-serial library at `vendor/awto-mcp-serial/docs/DISCOVERY.md`, because it
+> is a generic serial concern that every device repo needs. `discover_devices`
+> here is a thin wrapper over that shared `discover()` primitive. The measured
+> RD6024 trial below is the original source data behind the rule — kept here.
+
 **Never open the same serial port from more than one thread at once.** Discovery
 fans out across *ports* in parallel but probes addresses *within* a port
 serially, for a concrete, measured reason.

--- a/riden_daemon.py
+++ b/riden_daemon.py
@@ -32,6 +32,7 @@ from riden_transport import (
     list_riden_candidate_ports,
     list_serial_ports,
     list_serial_ports_ranked,
+    vendor_discover,
 )
 
 from protocol import (
@@ -1690,21 +1691,25 @@ def discover_devices(
 ) -> dict[str, Any]:
     """Discover reachable Riden PSUs across serial ports and Modbus addresses.
 
-    This helper is intentionally outside RidenWorker so CLI/MCP can discover
-    devices before any worker is configured.
+    Thin wrapper over the shared, device-agnostic ``discover()`` primitive in
+    awto-serial (vendored). riden contributes only the two device-specific
+    pieces: which ports to consider (CH340 VID, with a fallback) and a Modbus
+    identity probe that sweeps the requested Modbus addresses on the port
+    discover() opens. All the generic machinery — identify-before-open,
+    one-owner-thread-per-port, bounded fan-out, the ``max_scan_s`` budget with
+    ``skipped`` accounting, and high-resolution timing — lives in the shared
+    primitive (see the vendored ``docs/DISCOVERY.md`` for the one-thread-per-port
+    rule and contention proof that motivated extracting it).
 
-    Probes run in parallel (one thread per port x address) via a
-    ThreadPoolExecutor — each probe is a blocking serial read that releases the
-    GIL while waiting, and under the free-threaded build (python3.14t) they run
-    with true parallelism. Wall-clock is therefore ~one probe timeout regardless
-    of how many ports/addresses are scanned, instead of their serial sum.
-
-    A hard total-time budget (``max_scan_s``) still caps the whole scan: any
-    probe not finished by the deadline is recorded as ``skipped`` (no silent
-    truncation) and its thread is left to unwind on its own short timeout. With
-    the defaults (0.2 s / 1 retry) every probe is <=~0.25 s, so even a wide grid
-    completes well inside the budget.
+    The response shape is unchanged from the previous bespoke implementation so
+    MCP/CLI consumers are unaffected.
     """
+    if vendor_discover is None:
+        raise RuntimeError(
+            "shared discover() primitive unavailable — the awto-serial submodule "
+            "is not initialised. Run: git submodule update --init --recursive"
+        )
+
     if addresses is None or len(addresses) == 0:
         addresses = [1]
     addresses = [int(a) for a in addresses if 1 <= int(a) <= 247]
@@ -1715,10 +1720,12 @@ def discover_devices(
 
     if ports is None or len(ports) == 0:
         # Identify Riden ports by USB VID (CH340 0x1A86) BEFORE opening anything.
-        # This skips the host's ST-Link / Pico / ESP32-JTAG CDC-ACM devices,
-        # which are not Riden and can hang on a Modbus probe's open(). Only fall
-        # back to the broader ranked list if no CH340 port is present (e.g. a
-        # generic USB-serial adapter or a Bluetooth rfcomm link).
+        # Skips the host's ST-Link / Pico / ESP32-JTAG CDC-ACM devices, which are
+        # not Riden and can hang on a probe's open(). Fall back to the broader
+        # ranked list only if no CH340 port is present (a generic USB-serial
+        # adapter or a Bluetooth rfcomm link). This riden-specific selection adds
+        # value over a plain VID allowlist, so we keep it and hand discover() an
+        # explicit port list.
         ports = list_riden_candidate_ports()
         if not ports:
             ports = [
@@ -1726,129 +1733,108 @@ def discover_devices(
                 if ("/ttyUSB" in d or "/ttyACM" in d or "/rfcomm" in d)
             ]
 
-    found: list[dict[str, Any]] = []
-    errors: list[dict[str, Any]] = []
-    skipped: list[dict[str, Any]] = []
-    timed_out = False
+    # The shared primitive only learns whether a port is found-or-not; we keep
+    # the richer per-address Modbus error detail here, accumulated across the
+    # probe threads discover() fans out (hence the lock).
+    probe_errors: dict[str, list[dict[str, Any]]] = {}
+    errors_lock = threading.Lock()
 
-    log.info(
-        "discovery: %d port(s) × %d address(es), timeout=%.0fms retries=%d budget=%.1fs, parallel by port",
-        len(ports), len(addresses), timeout_s * 1000, retries, max_scan_s,
-    )
+    def _modbus_probe(ser) -> dict[str, Any] | None:
+        """Sweep the requested Modbus addresses on discover()'s open port.
 
-    def _scan_port(port: str) -> dict[str, Any]:
-        """Probe all addresses on ONE port, serially, in a single worker thread.
-
-        Parallelism is across ports, never within a port: opening the same
-        serial device from multiple threads at once corrupts every reader, so
-        each port has exactly one owner thread that tries its addresses in
-        sequence. Stops at the first address that answers (one PSU per port).
-        Times each address at the highest resolution available (perf_counter).
+        Returns the first PSU's identity dict, or None if no address answers.
+        Borrows discover()'s open handle via SerialTransport.from_open_serial —
+        it never opens its own port, preserving one owner thread per port.
         """
-        port_found: list[dict[str, Any]] = []
-        port_errors: list[dict[str, Any]] = []
+        port = getattr(ser, "port", "?")
+        # CH34x adapters emit USB line-status frames on first open; let them
+        # arrive and flush once before Modbus framing. (SerialTransport.open()
+        # used to do this settle per-open; here it is once per port.)
+        time.sleep(0.05)
+        try:
+            ser.reset_input_buffer()
+        except Exception:
+            pass
+        local_errors: list[dict[str, Any]] = []
         for addr in addresses:
             t0 = time.perf_counter()
-            tr = SerialTransport(
-                port=port, baud=baud, address=addr,
-                retries=max(1, int(retries)), timeout=float(timeout_s),
+            tr = SerialTransport.from_open_serial(
+                ser, address=addr, retries=max(1, int(retries)),
             )
             try:
-                tr.open()
                 psu = RidenDevice(tr)
                 fw_raw = int(getattr(psu, "fw", 0))
                 ms = (time.perf_counter() - t0) * 1000.0
                 log.debug("probe %s addr=%d → FOUND %s in %.3fms",
                           port, addr, getattr(psu, "type", "?"), ms)
-                port_found.append({
-                    "port": port, "baud": int(baud), "address": int(addr),
+                return {
+                    "address": int(addr),
                     "model": getattr(psu, "type", "unknown"),
                     "device_id": int(getattr(psu, "id", 0)),
                     "serial": str(getattr(psu, "sn", "")),
                     "fw_raw": fw_raw,
                     "fw": f"v{fw_raw // 100}.{fw_raw % 100:02d}",
-                    "probe_ms": round(ms, 3),
-                })
-                break  # one PSU per port; don't probe further addresses
+                }
             except Exception as exc:
                 ms = (time.perf_counter() - t0) * 1000.0
                 log.debug("probe %s addr=%d → none in %.3fms (%s)", port, addr, ms, exc)
-                port_errors.append({
+                local_errors.append({
                     "port": port, "baud": int(baud), "address": int(addr),
                     "error": str(exc), "probe_ms": round(ms, 3),
                 })
-            finally:
-                try:
-                    tr.close()
-                except Exception:
-                    pass
-        return {"found": port_found, "errors": port_errors}
+        if include_errors and local_errors:
+            with errors_lock:
+                probe_errors.setdefault(port, []).extend(local_errors)
+        return None
 
-    # Fan out across PORTS (per CODING_STYLE bounded fan-out). One DAEMON thread
-    # per port (capped by a semaphore) — never multiple threads on the same
-    # device. Daemon threads are deliberate: a serial open() can block past the
-    # budget (the read timeout does not bound open()), and ThreadPoolExecutor
-    # uses non-daemon workers whose stuck open() would keep the whole process
-    # alive at interpreter exit even after we have the result. Daemon threads
-    # are abandoned cleanly when the process exits. Wall-clock is ~(addresses ×
-    # probe_timeout) per port, all ports overlapped — roughly one port's cost.
-    workers = min(DISCOVERY_MAX_WORKERS, len(ports))
-    slots = threading.Semaphore(max(1, workers))
-    results_lock = threading.Lock()
-    results: dict[str, dict[str, Any]] = {}
-
-    def _worker(port: str) -> None:
-        with slots:
-            res = _scan_port(port)
-        with results_lock:
-            results[port] = res
-
-    t_start = time.perf_counter()
-    threads = []
-    for port in ports:
-        t = threading.Thread(target=_worker, args=(port,), daemon=True,
-                             name=f"riden-discover-{port}")
-        t.start()
-        threads.append((port, t))
-
-    # Join each port's thread within the remaining budget. A port whose thread
-    # has not finished by the deadline is recorded as skipped (every address on
-    # it) and its daemon thread is abandoned — no silent truncation, no hang.
-    deadline = time.monotonic() + float(max_scan_s)
-    for port, t in threads:
-        remaining = deadline - time.monotonic()
-        if remaining > 0:
-            t.join(timeout=remaining)
-        if t.is_alive():
-            timed_out = True
-            for addr in addresses:
-                skipped.append({"port": port, "baud": int(baud), "address": int(addr)})
-
-    with results_lock:
-        for port, _ in threads:
-            res = results.get(port)
-            if res is None:
-                continue  # already counted as skipped above
-            found.extend(res["found"])
-            if include_errors:
-                errors.extend(res["errors"])
-
-    total_ms = (time.perf_counter() - t_start) * 1000.0
-    log.info(
-        "discovery: %d found, %d skipped (timed_out=%s) in %.3fms",
-        len(found), len(skipped), timed_out, total_ms,
+    result = vendor_discover(
+        probe=_modbus_probe,
+        ports=ports,               # riden-resolved candidates; discover() won't re-filter
+        bauds=[int(baud)],         # riden uses a fixed baud; no baud scanning
+        timeout_s=float(timeout_s),
+        max_scan_s=float(max_scan_s),
+        max_workers=DISCOVERY_MAX_WORKERS,
+        include_errors=include_errors,
     )
 
+    # Map the shared response back to riden's historical shape (flatten identity).
+    found = [
+        {
+            "port": f["port"], "baud": int(f["baud"]),
+            "address": f["identity"]["address"],
+            "model": f["identity"]["model"],
+            "device_id": f["identity"]["device_id"],
+            "serial": f["identity"]["serial"],
+            "fw_raw": f["identity"]["fw_raw"],
+            "fw": f["identity"]["fw"],
+            "probe_ms": f.get("probe_ms"),
+        }
+        for f in result["found"]
+    ]
+
+    # The shared primitive reports each over-budget port once; expand to riden's
+    # per-address skipped entries so the response shape is unchanged.
+    skipped: list[dict[str, Any]] = []
+    for s in result["skipped"]:
+        for addr in addresses:
+            skipped.append({"port": s["port"], "baud": int(baud), "address": int(addr)})
+
+    errors: list[dict[str, Any]] = []
+    if include_errors:
+        errors.extend(result.get("errors", []))     # port open failures
+        for port_errs in probe_errors.values():      # per-address Modbus errors
+            errors.extend(port_errs)
+
     return {
-        "ports_scanned": ports,
+        "ports_scanned": result["ports_scanned"],
         "baud": int(baud),
         "addresses_scanned": addresses,
         "found": found,
         "found_count": len(found),
-        "errors": errors if include_errors else [],
-        "timed_out": timed_out,
+        "errors": errors,
+        "timed_out": result["timed_out"],
         "max_scan_s": float(max_scan_s),
-        "scan_ms": round(total_ms, 3),
+        "scan_ms": result["scan_ms"],
         "skipped": skipped,
     }
 

--- a/riden_transport.py
+++ b/riden_transport.py
@@ -79,6 +79,76 @@ def _load_vendor_known_devices() -> dict[tuple[int, int], dict]:
 KNOWN_DEVICES = _load_vendor_known_devices()
 
 
+def _load_vendor_serial_daemon():
+    """Load the vendored awto-serial ``serial_daemon`` module in isolation.
+
+    The generic device-discovery primitive (``discover``) lives in the shared
+    awto-serial library; we consume it from the ``vendor/awto-mcp-serial``
+    submodule rather than reimplementing it. The catch: ``serial_daemon.py`` does
+    ``from protocol import ...``, and this repo has its OWN top-level
+    ``protocol.py`` (a different module). So we temporarily register the vendored
+    ``protocol`` in ``sys.modules`` for the duration of the load and restore the
+    previous binding afterwards — the vendored daemon binds the vendored protocol
+    constants, and riden's own ``import protocol`` is left untouched.
+
+    Returns the loaded module, or ``None`` if the submodule is absent (callers
+    degrade gracefully and tell the user to init submodules).
+    """
+    import sys as _sys
+
+    vendor_dir = _os.path.join(_os.path.dirname(__file__), "vendor", "awto-mcp-serial")
+    sd_path = _os.path.join(vendor_dir, "serial_daemon.py")
+    proto_path = _os.path.join(vendor_dir, "protocol.py")
+    if not (_os.path.exists(sd_path) and _os.path.exists(proto_path)):
+        log.warning(
+            "vendored awto-serial not found under %s; discovery primitive unavailable "
+            "(run 'git submodule update --init --recursive')",
+            vendor_dir,
+        )
+        return None
+
+    # Load the vendored protocol under a private, collision-free name first.
+    proto_spec = importlib.util.spec_from_file_location(
+        "awto_serial_vendor_protocol", proto_path,
+    )
+    if proto_spec is None or proto_spec.loader is None:
+        log.warning("failed to spec vendored protocol at %s; discovery unavailable", proto_path)
+        return None
+    proto_mod = importlib.util.module_from_spec(proto_spec)
+
+    saved_protocol = _sys.modules.get("protocol")
+    try:
+        proto_spec.loader.exec_module(proto_mod)
+        # Expose it as 'protocol' ONLY while serial_daemon's top-level
+        # `from protocol import ...` runs, so it binds the vendored constants.
+        _sys.modules["protocol"] = proto_mod
+        sd_spec = importlib.util.spec_from_file_location(
+            "awto_serial_vendor_daemon", sd_path,
+        )
+        if sd_spec is None or sd_spec.loader is None:
+            log.warning("failed to spec vendored serial_daemon at %s", sd_path)
+            return None
+        sd_mod = importlib.util.module_from_spec(sd_spec)
+        _sys.modules[sd_spec.name] = sd_mod  # register before exec (import best practice)
+        sd_spec.loader.exec_module(sd_mod)
+        return sd_mod
+    except Exception as exc:
+        log.warning("error loading vendored serial_daemon from %s: %s", sd_path, exc)
+        return None
+    finally:
+        # Restore riden's own 'protocol' binding (or clear our temporary one).
+        if saved_protocol is not None:
+            _sys.modules["protocol"] = saved_protocol
+        else:
+            _sys.modules.pop("protocol", None)
+
+
+_vendor_serial_daemon = _load_vendor_serial_daemon()
+
+# The shared discovery primitive, or None if the submodule is not initialised.
+vendor_discover = getattr(_vendor_serial_daemon, "discover", None)
+
+
 # ---------------------------------------------------------------------------
 # Serial port auto-detection for Riden PSUs
 # ---------------------------------------------------------------------------
@@ -299,12 +369,41 @@ class SerialTransport(RidenTransport):
         self._retries = retries
         self._timeout = timeout
         self._serial: Serial | None = None
+        self._borrowed = False
+
+    @classmethod
+    def from_open_serial(
+        cls,
+        ser: Serial,
+        address: int = 1,
+        retries: int = 3,
+    ) -> "SerialTransport":
+        """Wrap an ALREADY-OPEN ``serial.Serial`` instead of opening a new port.
+
+        Used by the shared ``discover()`` probe: discover() owns the port
+        lifecycle (one ``open()`` per port, enforcing one-owner-thread-per-port),
+        so the probe must never open its own handle. ``open()``/``close()`` are
+        therefore no-ops on a borrowed transport — the port is left for its owner
+        to reset and close.
+        """
+        self = cls(
+            getattr(ser, "port", "<borrowed>"),
+            baud=getattr(ser, "baudrate", 115200),
+            address=address,
+            retries=retries,
+            timeout=getattr(ser, "timeout", 0.5) or 0.5,
+        )
+        self._serial = ser
+        self._borrowed = True
+        return self
 
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
 
     def open(self) -> None:
+        if self._borrowed:
+            return  # port already open and owned by discover() — never reopen
         try:
             self._serial = Serial(
                 self._port,
@@ -323,6 +422,8 @@ class SerialTransport(RidenTransport):
             raise IOError(f"failed to open {self._port}: {e}")
 
     def close(self) -> None:
+        if self._borrowed:
+            return  # borrowed port — its owner (discover) closes it, not us
         if self._serial is not None:
             try:
                 self._serial.close()

--- a/test_harness.py
+++ b/test_harness.py
@@ -25,10 +25,11 @@ import os
 import subprocess
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from protocol import make_err, make_ok
-from riden_daemon import RidenWorker
+from riden_daemon import RidenWorker, discover_devices
+from riden_transport import SerialTransport
 
 # Repo root — used as cwd for the CLI subprocess test. Derived from this
 # file's location so a rename of the checkout dir can't stale it again.
@@ -311,6 +312,126 @@ class TestDataStructures(unittest.TestCase):
         result = make_err(msg)
         self.assertFalse(result["ok"])
         self.assertEqual(result["error"], msg)
+
+
+# ---------------------------------------------------------------------------
+# Layer 5 — discover_devices (delegates to the shared awto-serial discover())
+# ---------------------------------------------------------------------------
+
+def _fake_serial_factory():
+    """serial.Serial(...) stand-in: returns a MagicMock port honouring attrs.
+
+    The shared discover() opens the port; the Modbus probe then borrows this
+    handle via SerialTransport.from_open_serial, so no real I/O happens (the
+    RidenDevice layer is mocked).
+    """
+    def _factory(port, baudrate=None, timeout=None, write_timeout=None):
+        m = MagicMock()
+        m.is_open = True
+        m.port = port
+        m.baudrate = baudrate
+        m.timeout = timeout
+        return m
+    return _factory
+
+
+def _mock_riden_device_class(target_address):
+    """Build a RidenDevice stand-in that 'answers' only at *target_address*.
+
+    Construction reads the identity block on real hardware and raises on a
+    silent address; the mock mirrors that — it raises for any other address so
+    the probe's address sweep behaves exactly as against a real bus.
+    """
+    class _MockDev:
+        def __init__(self, transport):
+            self.transport = transport
+            self.address = getattr(transport, "address", 1)
+            if self.address != target_address:
+                raise TimeoutError(f"no device at addr {self.address}")
+            self.id = 60241          # RD6024
+            self.sn = "00012345"
+            self.fw = 144
+            self.type = "RD6024"
+
+        def update(self):
+            pass
+
+        def close(self):
+            pass
+
+    return _MockDev
+
+
+class TestDiscovery(unittest.TestCase):
+
+    def test_from_open_serial_is_borrowed(self):
+        """A borrowed transport never opens or closes the underlying port."""
+        ser = MagicMock()
+        ser.port = "/dev/ttyUSB0"
+        ser.baudrate = 115200
+        ser.timeout = 0.2
+        tr = SerialTransport.from_open_serial(ser, address=3, retries=2)
+        self.assertEqual(tr.address, 3)
+        self.assertIs(tr._serial, ser)
+        tr.open()                       # no-op — already open and owned by discover
+        tr.close()                      # no-op — owner closes it, not us
+        ser.close.assert_not_called()
+
+    def test_discover_finds_device(self):
+        with patch("serial.Serial", side_effect=_fake_serial_factory()), \
+             patch("riden_daemon.RidenDevice", _mock_riden_device_class(1)), \
+             patch("riden_daemon.time.sleep"):           # skip the 50 ms CH34x settle
+            result = discover_devices(
+                ports=["/dev/ttyUSB0"], baud=115200, addresses=[1, 2],
+                timeout_s=0.05, max_scan_s=2.0,
+            )
+        self.assertEqual(result["found_count"], 1)
+        self.assertEqual(result["ports_scanned"], ["/dev/ttyUSB0"])
+        self.assertEqual(result["addresses_scanned"], [1, 2])
+        self.assertFalse(result["timed_out"])
+        dev = result["found"][0]
+        self.assertEqual(dev["port"], "/dev/ttyUSB0")
+        self.assertEqual(dev["baud"], 115200)
+        self.assertEqual(dev["address"], 1)
+        self.assertEqual(dev["model"], "RD6024")
+        self.assertEqual(dev["device_id"], 60241)
+        self.assertEqual(dev["serial"], "00012345")
+        self.assertEqual(dev["fw"], "v1.44")
+        self.assertIsNotNone(dev["probe_ms"])
+
+    def test_discover_no_device_records_per_address_errors(self):
+        with patch("serial.Serial", side_effect=_fake_serial_factory()), \
+             patch("riden_daemon.RidenDevice", _mock_riden_device_class(99)), \
+             patch("riden_daemon.time.sleep"):
+            result = discover_devices(
+                ports=["/dev/ttyUSB0"], baud=115200, addresses=[1, 2],
+                timeout_s=0.05, max_scan_s=2.0, include_errors=True,
+            )
+        self.assertEqual(result["found_count"], 0)
+        self.assertFalse(result["timed_out"])
+        # One error per swept address (richer detail than the shared primitive).
+        addr_errors = [e for e in result["errors"] if "address" in e]
+        self.assertEqual({e["address"] for e in addr_errors}, {1, 2})
+
+    def test_discover_no_candidate_ports(self):
+        with patch("riden_daemon.list_riden_candidate_ports", return_value=[]), \
+             patch("riden_daemon.list_serial_ports_ranked", return_value=[]), \
+             patch("serial.Serial", side_effect=AssertionError("must not open any port")):
+            result = discover_devices(baud=115200, addresses=[1])
+        self.assertEqual(result["found_count"], 0)
+        self.assertEqual(result["ports_scanned"], [])
+        self.assertEqual(result["skipped"], [])
+
+    def test_discover_response_shape_unchanged(self):
+        with patch("serial.Serial", side_effect=_fake_serial_factory()), \
+             patch("riden_daemon.RidenDevice", _mock_riden_device_class(1)), \
+             patch("riden_daemon.time.sleep"):
+            result = discover_devices(ports=["/dev/ttyUSB0"], addresses=[1], timeout_s=0.05)
+        for key in (
+            "ports_scanned", "baud", "addresses_scanned", "found", "found_count",
+            "errors", "timed_out", "max_scan_s", "scan_ms", "skipped",
+        ):
+            self.assertIn(key, result, f"discover_devices response missing {key}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #8.

Makes `discover_devices` a thin wrapper over the generic `discover()` primitive in awto-serial (awtoau/awto-serial#46) instead of carrying its own port-scanning fan-out. The hard-won generic concerns now live in the shared library; riden keeps only what's device-specific.

## What changed

**Submodule** — bumped `vendor/awto-mcp-serial` to the canonical repo (`awto-au/awto-mcp-serial` → `awtoau/awto-serial`) at the commit that adds `discover()`. After pulling: `git submodule update --init --recursive`.

**Isolated loader** (`riden_transport._load_vendor_serial_daemon`) — imports the vendored `serial_daemon` while temporarily shadowing `protocol` in `sys.modules`, so its `from protocol import …` binds the **vendored** constants and riden's own top-level `protocol.py` (imported in 5 files) is left untouched. Exposes `vendor_discover`.

**`SerialTransport.from_open_serial()`** — the Modbus probe borrows discover()'s open handle (`open`/`close` become no-ops) so it never opens its own port, preserving one owner thread per port.

**`discover_devices`** — now:
1. Resolves candidate ports with the existing riden-specific selection (CH340 VID filter + fallback to ranked ttyUSB/ttyACM/rfcomm) — kept because it adds value over a bare VID allowlist — and hands discover() an explicit port list.
2. Builds a Modbus identity probe that sweeps the requested addresses on discover()'s handle.
3. Maps the shared response back to the **unchanged** riden shape.

Only the duplicated thread+semaphore fan-out is removed.

## Acceptance (#8)

- [x] `discover_devices` delegates to `serial_daemon.discover` with a Modbus probe + CH340 selection
- [x] Existing discovery response shape preserved (verified against CLI `json.dumps` passthrough + MCP auto-discovery reading `model`/`port`/`serial`/`baud`/`address`)
- [x] Duplicated port-fan-out removed (port-scoring kept — adds value)
- [x] Tests updated/passing (5 new; full suite **19 passing**, no hardware)
- [x] `USB_TESTING.md` points at the shared `docs/DISCOVERY.md` as canonical, keeping the measured RD6024 contention table as source data

## Test

```
.venv/bin/python test_harness.py    # Ran 19 tests — OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</content>
