### PR TITLE
feat: firmware command, MIT bootloader flasher, write-path test, CLI rename

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Copilot Instructions — awto-riden
 
 > **Now CLI-first (see issue #7).** The primary interface is the direct CLI
-> `ttu_cli.py` (`python3 ttu_cli.py --port /dev/ttyUSB0 status`), which talks to
+> `awto_riden.py` (`python3 awto_riden.py --port /dev/ttyUSB0 status`), which talks to
 > `RidenWorker` over serial with no daemon. The **MCP server is parked** under
 > `mcp/` and is off the active path; the section below applies only if you
 > deliberately re-enable it.
@@ -133,7 +133,7 @@ Example: raw `V_OUT = 1200` with `v_multi = 100` → `12.00 V`.
 
 | File | Purpose |
 |---|---|
-| `ttu_cli.py` | **Primary interface** — direct-serial CLI (status, set, benchmark, discovery) |
+| `awto_riden.py` | **Primary interface** — direct-serial CLI (status, set, benchmark, discovery) |
 | `riden_daemon.py` | `RidenWorker` — high-level PSU API (waveform, status, logging, …) |
 | `riden_transport.py` | `SerialTransport` — raw Modbus RTU over pyserial (FC03/FC06/FC16) |
 | `riden_register.py` | Modbus register address constants |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,17 +54,17 @@ The original daemon added unnecessary complexity:
 - Used by: CLI, MCP server, tests
 
 ### `mcp/mcp_server.py` — FastMCP stdio server (PARKED — see issue #7)
-- Parked under `mcp/`; development is CLI-first (`ttu_cli.py`). Kept for when
+- Parked under `mcp/`; development is CLI-first (`awto_riden.py`). Kept for when
   AI-agent / Copilot access is wanted again.
 - Opens serial port directly
 - Registers tools: `rd_status()`, `rd_set_voltage()`, `rd_set_current()`, etc.
 - All tool calls share the serial connection
 - Usage: `python3 mcp/mcp_server.py --port /dev/ttyUSB0`
 
-### `ttu_cli.py` — One-shot CLI
+### `awto_riden.py` — One-shot CLI
 - Opens serial port, runs one command, closes
 - Subcommands: `status`, `set-voltage`, `set-current`, `output`, `power-cycle`, `info`
-- Usage: `python3 ttu_cli.py --port /dev/ttyUSB0 status`
+- Usage: `python3 awto_riden.py --port /dev/ttyUSB0 status`
 
 ### `protocol.py` — Shared helpers (kept for history)
 - JSON encoding/decoding for potential future daemon rebuild
@@ -81,11 +81,11 @@ The original daemon added unnecessary complexity:
 ### CLI Command
 
 ```bash
-python3 ttu_cli.py --port /dev/ttyUSB0 status
-python3 ttu_cli.py --port /dev/ttyUSB0 set-voltage 12.0
-python3 ttu_cli.py --port /dev/ttyUSB0 set-current 2.0
-python3 ttu_cli.py --port /dev/ttyUSB0 output on
-python3 ttu_cli.py --port /dev/ttyUSB0 power-cycle --seconds 3
+python3 awto_riden.py --port /dev/ttyUSB0 status
+python3 awto_riden.py --port /dev/ttyUSB0 set-voltage 12.0
+python3 awto_riden.py --port /dev/ttyUSB0 set-current 2.0
+python3 awto_riden.py --port /dev/ttyUSB0 output on
+python3 awto_riden.py --port /dev/ttyUSB0 power-cycle --seconds 3
 ```
 
 ### MCP Server (for Copilot)
@@ -116,7 +116,7 @@ python3 mcp_server.py --port /dev/ttyUSB0
 
 ```toml
 [project.scripts]
-awto-riden = "ttu_cli:main"
+awto-riden = "awto_riden:main"
 awto-riden-mcp = "mcp_server:main"
 ```
 

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -51,15 +51,19 @@ to a revision under our control and does not introduce code changes.
 
 ---
 
-## tjko/riden-flashtool *(indirect reference only)*
+## tjko/riden-flashtool *(protocol reference only — no code used)*
 
-**Repository:** https://github.com/tjko/riden-flashtool  
-**License:** AGPL-3.0  
+**Repository:** https://github.com/tjko/riden-flashtool (fork of bdd/riden-flashtool)  
+**License:** AGPL-3.0 (repository `LICENSE`; the `flash-rd.py` header inconsistently states GPL-3.0 — both are copyleft)  
 **Author:** Timo Kokkonen (tjko), mdjurfeldt, cygeus, JorgHendriks  
 
-Riden firmware flash tool, credited by ShayBox/Riden as the basis for their
-`Bootloader` class. Included here for lineage completeness. **Not used by this project.**
-AGPL-3.0 terms do not apply to this codebase.
+Riden firmware flash tool. This project's `riden_flash.py` is an **independent,
+clean MIT reimplementation** of the publicly-observable Riden serial *bootloader
+protocol* (the `queryd`/`upfirm`/`getinf` text commands, the 64-byte chunked
+transfer, and the `SYSTEM`←`REBOOT_MAGIC` reboot — the latter already documented
+in `riden_register.py`). Only those **factual protocol/interface details** were
+used as a reference; **no source code was copied or adapted** from riden-flashtool.
+Accordingly the AGPL-3.0 copyleft does **not** propagate to this MIT codebase.
 
 ---
 
@@ -70,6 +74,6 @@ AGPL-3.0 terms do not apply to this codebase.
 | Baldanos/rd6006 | Apache-2.0 | Indirectly (via ShayBox) | No |
 | ShayBox/Riden | MIT | Yes (via awto-au/riden fork) | No |
 | awto-au/riden | MIT | Yes | No |
-| tjko/riden-flashtool | AGPL-3.0 | No | No |
+| tjko/riden-flashtool | AGPL-3.0 | Protocol reference only (no code) | No |
 
 This project is released under the **MIT license**. See `LICENSE` for the full text.

--- a/BLE_ROADMAP.md
+++ b/BLE_ROADMAP.md
@@ -111,7 +111,7 @@ same Modbus RTU FC03/FC06/FC16 frames (the framing helpers can be shared with
    path). Replace `<MAC>` with the actual paired device — none is paired today,
    see `BT_STATUS.md`:
    ```bash
-   python3 ttu_cli.py --port <MAC> status
+   python3 awto_riden.py --port <MAC> status
    ```
 
 2. Verify response matches the USB serial baseline (`--port /dev/ttyUSB0`)
@@ -148,7 +148,7 @@ python3 ble_discover.py
 # Update RK6006 GATT UUIDs in BleTransport (riden_transport.py)
 
 # Test directly via the CLI, passing the paired MAC as --port
-python3 ttu_cli.py --port <MAC> status
+python3 awto_riden.py --port <MAC> status
 ```
 
 ## References

--- a/BT_STATUS.md
+++ b/BT_STATUS.md
@@ -30,8 +30,8 @@ talks directly over serial (no daemon required) via our own `SerialTransport`
 + `RidenDevice` (`riden_transport.py` / `riden_daemon.py`):
 
 ```bash
-python3 ttu_cli.py --port /dev/ttyUSB0 ping
-python3 ttu_cli.py --port /dev/ttyUSB0 status
+python3 awto_riden.py --port /dev/ttyUSB0 ping
+python3 awto_riden.py --port /dev/ttyUSB0 status
 ```
 
 Measured round-trip latency is ~131 ms median — this is the RD6006 firmware

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ MCP server and CLI for RuiDeng/Riden RD60xx and RK6006 power supplies.
 This repository provides a direct serial control stack for AI agents and humans:
 
 - MCP tools (`rd_*`) for Copilot/Claude workflows
-- CLI (`ttu_cli.py`) for bench scripting
+- CLI (`awto_riden.py`) for bench scripting
 - Timing profiler to recommend stable poll cadence
 - Characterisation helpers (VI sweep, inrush capture, waveform output)
 
@@ -38,8 +38,8 @@ cd awto-mcp-riden
 python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 
-python3 ttu_cli.py --port /dev/ttyUSB0 status
-python3 ttu_cli.py --port /dev/ttyUSB0 profile-serial --count 20 --sleep-ms 100
+python3 awto_riden.py --port /dev/ttyUSB0 status
+python3 awto_riden.py --port /dev/ttyUSB0 profile-serial --count 20 --sleep-ms 100
 ```
 
 ## Timing graphs (updated)
@@ -145,7 +145,7 @@ Bluetooth RFCOMM links can be compared directly.
 CLI:
 
 ```bash
-python3 ttu_cli.py --port /dev/ttyUSB0 profile-serial --count 20 --sleep-ms 100
+python3 awto_riden.py --port /dev/ttyUSB0 profile-serial --count 20 --sleep-ms 100
 ```
 
 MCP:
@@ -232,7 +232,7 @@ Main categories:
 ## CLI interface summary
 
 ```bash
-python3 ttu_cli.py --port /dev/ttyUSB0 [--baud 115200] [--address 1] <command>
+python3 awto_riden.py --port /dev/ttyUSB0 [--baud 115200] [--address 1] <command>
 ```
 
 Common commands:
@@ -252,7 +252,7 @@ Common commands:
 
 ```text
 Agent/CLI
-  -> mcp_server.py / ttu_cli.py
+  -> mcp_server.py / awto_riden.py
   -> riden_daemon.py (RidenWorker)
   -> riden_transport.py (pymodbus + raw serial fallback)
   -> Modbus RTU over USB or RFCOMM

--- a/USB_TESTING.md
+++ b/USB_TESTING.md
@@ -37,9 +37,9 @@ ls -la /dev/ttyUSB* /dev/ttyACM* 2>/dev/null
 ls -la /dev/rfcomm* 2>/dev/null
 
 # Then pass the chosen interface explicitly
-python3 ttu_cli.py --port /dev/ttyUSB1 status
+python3 awto_riden.py --port /dev/ttyUSB1 status
 # or
-python3 ttu_cli.py --port /dev/rfcomm0 status
+python3 awto_riden.py --port /dev/rfcomm0 status
 ```
 
 ## Run Daemon
@@ -62,11 +62,11 @@ python3 riden_daemon.py --port /dev/ttyUSB0 --baud 115200
 cd /home/dan/git/awto-mcp-riden
 
 # Ping daemon
-python3 ttu_cli.py ping
+python3 awto_riden.py ping
 # Output: {"ok": true}
 
 # Get PSU status
-python3 ttu_cli.py status
+python3 awto_riden.py status
 # Output:
 # {
 #   "voltage_set": 6.0,
@@ -77,27 +77,27 @@ python3 ttu_cli.py status
 # }
 
 # Set voltage
-python3 ttu_cli.py set-voltage 12.0
+python3 awto_riden.py set-voltage 12.0
 
 # Enable/disable output
-python3 ttu_cli.py output on
-python3 ttu_cli.py output off
+python3 awto_riden.py output on
+python3 awto_riden.py output off
 
 # Power cycle (5 second off, then on)
-python3 ttu_cli.py power-cycle 5
+python3 awto_riden.py power-cycle 5
 
 # Set protections
-python3 ttu_cli.py set-ovp 15.0
-python3 ttu_cli.py set-ocp 2.0
+python3 awto_riden.py set-ovp 15.0
+python3 awto_riden.py set-ocp 2.0
 
 # Start logging status every 100ms to file
-python3 ttu_cli.py log-start /tmp/psu-log.txt 100
+python3 awto_riden.py log-start /tmp/psu-log.txt 100
 
 # Stop logging
-python3 ttu_cli.py log-stop
+python3 awto_riden.py log-stop
 
 # View daemon health
-python3 ttu_cli.py info
+python3 awto_riden.py info
 # Output: {
 #   "pid": 12345,
 #   "rss_mb": 45.2,
@@ -114,7 +114,7 @@ python3 ttu_cli.py info
 
 ```bash
 # Enable debug logging
-python3 ttu_cli.py --verbose status
+python3 awto_riden.py --verbose status
 
 # Or daemon with debug level
 python3 riden_daemon.py --port /dev/ttyUSB0 --level DEBUG

--- a/awto_riden.py
+++ b/awto_riden.py
@@ -331,6 +331,28 @@ def main() -> None:
     sub.add_parser("capabilities", help="show API capabilities and error codes", formatter_class=_F)
     sub.add_parser("status", help="show current PSU state", formatter_class=_F)
     sub.add_parser("info", help="show PSU process health", formatter_class=_F)
+    sub.add_parser("firmware", help="show device identity (model, id, serial, firmware)", formatter_class=_F)
+
+    sp_flash = sub.add_parser(
+        "flash",
+        help="reboot into the bootloader and optionally flash a firmware .bin",
+        formatter_class=_F,
+    )
+    sp_flash.add_argument(
+        "firmware",
+        nargs="?",
+        help="firmware .bin file; if omitted, only reboot to bootloader and report info",
+    )
+    sp_flash.add_argument(
+        "--yes",
+        action="store_true",
+        help="confirm: this reboots the unit into the bootloader (and writes firmware if a file is given)",
+    )
+    sp_flash.add_argument(
+        "--force",
+        action="store_true",
+        help="flash even if model / firmware-file checks fail (DANGEROUS)",
+    )
 
     sp_mon = sub.add_parser("monitor", help="live-poll PSU state to the terminal until Ctrl-C", formatter_class=_F)
     sp_mon.add_argument(
@@ -519,6 +541,40 @@ def main() -> None:
         )
         print(json.dumps(result, indent=2))
         return
+    if args.subcmd == "flash":
+        # Flashing speaks the bootloader protocol, not Modbus — handle it before
+        # the normal RidenWorker connect. It changes device state, so require --yes.
+        from riden_flash import flash_firmware, FlashError
+        if not args.yes:
+            print(json.dumps({
+                "error": "the flash command reboots the unit into the bootloader "
+                         "(and overwrites firmware if a file is given). Re-run with --yes.",
+                "code": "ECONFIRM",
+            }, indent=2), file=sys.stderr)
+            sys.exit(2)
+
+        def _progress(done: int, total: int) -> None:
+            pct = (100.0 * done / total) if total else 100.0
+            print(f"\rflashing {done}/{total} bytes ({pct:.0f}%)",
+                  end="", file=sys.stderr, flush=True)
+
+        try:
+            result = flash_firmware(
+                args.port,
+                args.firmware,
+                baud=args.baud,
+                address=args.address,
+                confirm=bool(args.yes),
+                force=bool(args.force),
+                progress=_progress if args.firmware else None,
+            )
+            if args.firmware:
+                print("", file=sys.stderr)  # newline after the progress line
+        except FlashError as e:
+            print(json.dumps({"error": str(e), "code": "EFLASH"}), file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(result, indent=2))
+        return
 
     # Open serial connection
     try:
@@ -557,6 +613,8 @@ def main() -> None:
             result = worker.status()
         elif c == "info":
             result = worker.info()
+        elif c == "firmware":
+            result = worker.firmware()
         elif c == "set-voltage":
             worker.set_voltage(args.volts)
             result = worker.status()

--- a/docs/registers.md
+++ b/docs/registers.md
@@ -30,8 +30,8 @@ Recommended verification workflow (existing interfaces only):
 
 ```bash
 source .venv/bin/activate
-python3 ttu_cli.py --port /dev/ttyUSBX --baud 115200 --address 1 register-scan --start 0 --end 260 --batch 50 --report-only
-python3 ttu_cli.py --port /dev/ttyUSBX --baud 115200 --address 1 diff-scan --start 0 --end 260 --batch 50 --settle-ms 300 --unknown-only
+python3 awto_riden.py --port /dev/ttyUSBX --baud 115200 --address 1 register-scan --start 0 --end 260 --batch 50 --report-only
+python3 awto_riden.py --port /dev/ttyUSBX --baud 115200 --address 1 diff-scan --start 0 --end 260 --batch 50 --settle-ms 300 --unknown-only
 ```
 
 If a unit does not answer at address 1, retry with its configured Modbus address.

--- a/mcp/mcp_server.py
+++ b/mcp/mcp_server.py
@@ -1,7 +1,7 @@
 """
 awto-riden MCP server — direct serial, multi-PSU.
 
-PARKED (see issue #7): development is CLI-first for now (ttu_cli.py talks to
+PARKED (see issue #7): development is CLI-first for now (awto_riden.py talks to
 RidenWorker directly). The MCP server is not on the active path and was moved
 under ./mcp/. Kept for when AI-agent / Copilot access is wanted again.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 ]
 
 [project.scripts]
-awto-riden = "ttu_cli:main"
+awto-riden = "awto_riden:main"
 # awto-riden-mcp: parked (see issue #7 / mcp/). The MCP server lives at
 # mcp/mcp_server.py and is run directly (python3 mcp/mcp_server.py), not as a
 # console script — a "mcp.mcp_server" entry point would collide with the PyPI

--- a/riden_client.py
+++ b/riden_client.py
@@ -4,7 +4,7 @@ Unix domain socket defined in protocol.py.
 
 PARKED (see issue #7): development is CLI-first for now. This client pairs with
 riden_server.py, which is kept for a future multi-instrument hub, not the
-active path. Use ttu_cli.py for direct serial control.
+active path. Use awto_riden.py for direct serial control.
 
 Usage as a library:
     from riden_client import RidenClient

--- a/riden_daemon.py
+++ b/riden_daemon.py
@@ -1,7 +1,7 @@
 """
 awto-riden RidenWorker — thread-safe wrapper for Riden RD60xx PSU control.
 
-Used by both the CLI (ttu_cli.py) and MCP server (mcp_server.py).
+Used by both the CLI (awto_riden.py) and MCP server (mcp_server.py).
 Each caller opens the serial port independently; Modbus serializes at protocol level.
 
 Transport: USB serial (/dev/ttyUSB0), Bluetooth serial (/dev/rfcomm0), or native BLE.

--- a/riden_flash.py
+++ b/riden_flash.py
@@ -1,0 +1,264 @@
+# riden_flash.py — Riden RD/RK60xx serial *bootloader* firmware loader.
+#
+# Lets firmware be flashed from Linux without the vendor PC software. Flashing is
+# NOT Modbus register I/O — it speaks the unit's text-based bootloader protocol —
+# so this module owns its own serial port rather than going through
+# SerialTransport/RidenDevice (one owner, one port).
+#
+# LICENCE: MIT, same as the rest of this project. This is an INDEPENDENT
+# implementation of the publicly-documented bootloader protocol below; it copies
+# no third-party code. The protocol behaviour was cross-checked against the
+# (GPLv3) tjko/riden-flashtool and bdd/riden-flashtool projects — credited in
+# ATTRIBUTION.md as protocol references only.
+#
+# Bootloader serial protocol (8N1, default 115200 baud):
+#   - b"queryd\r\n"   -> b"boot"   (4 bytes)  when already in bootloader mode
+#   - Modbus FC06 write REBOOT_MAGIC (0x1601) to the SYSTEM register (0x100)
+#                     -> b"\xfc", after which the unit reboots into the bootloader
+#   - b"getinf\r\n"   -> 13-byte info block: b"inf" + serial(LE32) + model(LE16)
+#                        + pad + fw(byte, version*100)
+#   - b"upfirm\r\n"   -> b"upredy" (6 bytes), then the firmware image in 64-byte
+#                        chunks, each acknowledged with b"OK"
+#
+# SAFETY: flashing a wrong/mismatched image can brick the unit. flash_firmware()
+# refuses unless the bootloader-reported model is in SUPPORTED_MODELS and (when a
+# model can be parsed from the firmware filename) matches it — overridable only
+# with force=True.
+
+from __future__ import annotations
+
+import logging
+import re
+import struct
+import time
+
+import serial
+
+from riden_register import Register as R
+
+log = logging.getLogger("riden.flash")
+
+# Device ids (= Riden model numbers) known to speak this bootloader protocol.
+# Sources: riden-flashtool supported_models list + Riden model numbering.
+SUPPORTED_MODELS: frozenset[int] = frozenset({
+    60062,  # RD6006
+    60065,  # RD6006P
+    60066,  # RK6006
+    60121,  # RD6012
+    60125,  # RD6012P
+    60181,  # RD6018
+    60241,  # RD6024
+    60301,  # RD6030
+})
+
+CHUNK_SIZE = 64          # bootloader consumes the image in 64-byte blocks
+BOOTLOADER_QUERY = b"queryd\r\n"
+BOOTLOADER_OK = b"boot"
+UPFIRM_CMD = b"upfirm\r\n"
+UPFIRM_READY = b"upredy"
+GETINF_CMD = b"getinf\r\n"
+CHUNK_ACK = b"OK"
+REBOOT_ACK = b"\xfc"
+
+# The unit drops off the bus and re-enumerates after the reboot command; it is
+# unresponsive for a few seconds. 3 s matches the vendor updater's settle.
+REBOOT_WAIT_S = 3.0
+
+
+class FlashError(RuntimeError):
+    """Raised when the bootloader protocol does not behave as expected."""
+
+
+def _modbus_crc16(data: bytes) -> int:
+    crc = 0xFFFF
+    for b in data:
+        crc ^= b
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0xA001 if (crc & 0x0001) else (crc >> 1)
+    return crc
+
+
+def _fc06_frame(address: int, register: int, value: int) -> bytes:
+    """Build a Modbus-RTU FC06 (write single register) frame."""
+    pdu = struct.pack(">BBHH", address, 0x06, register, value)
+    return pdu + struct.pack("<H", _modbus_crc16(pdu))
+
+
+def model_from_filename(path: str) -> int | None:
+    """Best-effort: parse the Riden model id from a firmware filename.
+
+    Vendor images are named like ``RD60062_V1.32.bin`` / ``RD60066_V1.09.bin``;
+    the 5-digit group is the model id. Returns None if nothing plausible found.
+    """
+    for m in re.findall(r"(\d{5})", path):
+        if int(m) in SUPPORTED_MODELS:
+            return int(m)
+    return None
+
+
+class RidenBootloader:
+    """Client for the Riden serial bootloader (firmware flashing)."""
+
+    def __init__(self, port: str, baud: int = 115200, address: int = 1,
+                 timeout: float = 5.0) -> None:
+        self._port_name = port
+        self._baud = baud
+        self._address = address
+        self._timeout = timeout
+        self._ser: serial.Serial | None = None
+
+    # -- lifecycle --------------------------------------------------------
+    def open(self) -> None:
+        self._ser = serial.Serial(self._port_name, self._baud, timeout=self._timeout)
+
+    def close(self) -> None:
+        if self._ser is not None:
+            try:
+                self._ser.close()
+            finally:
+                self._ser = None
+
+    def __enter__(self) -> "RidenBootloader":
+        self.open()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    # -- low level --------------------------------------------------------
+    def _io(self) -> serial.Serial:
+        if self._ser is None:
+            raise FlashError("bootloader port not open")
+        return self._ser
+
+    def _write(self, data: bytes) -> None:
+        self._io().write(data)
+
+    def _read(self, count: int) -> bytes:
+        return self._io().read(count)
+
+    # -- protocol ---------------------------------------------------------
+    def in_bootloader(self) -> bool:
+        """Return True if the unit is already in bootloader mode."""
+        self._write(BOOTLOADER_QUERY)
+        return self._read(len(BOOTLOADER_OK)) == BOOTLOADER_OK
+
+    def enter_bootloader(self) -> None:
+        """Ensure the unit is in bootloader mode, rebooting it via Modbus if needed."""
+        if self.in_bootloader():
+            log.info("device already in bootloader mode")
+            return
+        # Normal mode: ask it to reboot into the bootloader by writing
+        # REBOOT_MAGIC to the SYSTEM register (see riden_register.py).
+        frame = _fc06_frame(self._address, R.SYSTEM, R.REBOOT_MAGIC)
+        log.info("rebooting into bootloader (SYSTEM <- 0x%04X)", R.REBOOT_MAGIC)
+        self._write(frame)
+        ack = self._read(1)
+        if ack != REBOOT_ACK:
+            raise FlashError(f"reboot-to-bootloader not acknowledged (got {ack!r})")
+        # Unit re-enumerates; unresponsive for a few seconds.
+        time.sleep(REBOOT_WAIT_S)
+        if not self.in_bootloader():
+            raise FlashError("device did not enter bootloader after reboot")
+
+    def info(self) -> dict:
+        """Query model / firmware / serial from the bootloader (``getinf``)."""
+        self._write(GETINF_CMD)
+        res = self._read(13)
+        if len(res) != 13 or res[0:3] != b"inf":
+            raise FlashError(f"invalid bootloader info response: {res!r}")
+        snum = res[6] << 24 | res[5] << 16 | res[4] << 8 | res[3]
+        model = res[8] << 8 | res[7]
+        fw_raw = res[11]
+        return {
+            "model": model,
+            "fw_raw": fw_raw,
+            "fw": f"v{fw_raw / 100:.2f}",
+            "serial": f"{snum:08d}",
+            "supported": model in SUPPORTED_MODELS,
+        }
+
+    def write_firmware(self, firmware: bytes, progress=None) -> None:
+        """Write *firmware* to the unit (it must already be in bootloader mode).
+
+        *progress*, if given, is called as ``progress(done_bytes, total_bytes)``
+        after each acknowledged chunk.
+        """
+        if not firmware:
+            raise FlashError("empty firmware image")
+        self._write(UPFIRM_CMD)
+        res = self._read(len(UPFIRM_READY))
+        if res != UPFIRM_READY:
+            raise FlashError(f"bootloader did not accept upfirm (got {res!r})")
+        total = len(firmware)
+        pos = 0
+        while pos < total:
+            self._write(firmware[pos:pos + CHUNK_SIZE])
+            ack = self._read(len(CHUNK_ACK))
+            if ack != CHUNK_ACK:
+                raise FlashError(f"firmware chunk at offset {pos} rejected (got {ack!r})")
+            pos += CHUNK_SIZE
+            if progress is not None:
+                progress(min(pos, total), total)
+
+
+def flash_firmware(
+    port: str,
+    firmware_path: str | None = None,
+    *,
+    baud: int = 115200,
+    address: int = 1,
+    confirm: bool = False,
+    force: bool = False,
+    progress=None,
+) -> dict:
+    """Reboot the unit to its bootloader and (optionally) flash a firmware image.
+
+    With *firmware_path* None this only reboots to the bootloader and returns its
+    reported info — useful to verify the path before committing to a flash. NOTE
+    that even this leaves the unit IN the bootloader; power-cycle it (or complete
+    a flash) to return to normal operation.
+
+    Actually writing firmware requires *confirm=True*. Safety: the
+    bootloader-reported model must be in SUPPORTED_MODELS, and (when the firmware
+    filename encodes a model) must match it — unless *force=True*.
+
+    Returns a dict: {bootloader info..., "flashed": bool, "bytes": int|None}.
+    """
+    file_model = model_from_filename(firmware_path) if firmware_path else None
+    firmware: bytes | None = None
+    if firmware_path is not None:
+        with open(firmware_path, "rb") as fh:
+            firmware = fh.read()
+
+    with RidenBootloader(port, baud=baud, address=address) as bl:
+        bl.enter_bootloader()
+        meta = bl.info()
+        log.info("bootloader: model=%s fw=%s sn=%s supported=%s",
+                 meta["model"], meta["fw"], meta["serial"], meta["supported"])
+
+        result = dict(meta)
+        result["flashed"] = False
+        result["bytes"] = None
+
+        if firmware is None:
+            return result  # reboot-to-bootloader + info only
+
+        if not confirm:
+            raise FlashError(
+                "refusing to flash without confirm=True (this overwrites device firmware)"
+            )
+        if not meta["supported"] and not force:
+            raise FlashError(
+                f"device model {meta['model']} not in SUPPORTED_MODELS; pass force=True to override"
+            )
+        if file_model is not None and file_model != meta["model"] and not force:
+            raise FlashError(
+                f"firmware file model {file_model} != device model {meta['model']}; "
+                "pass force=True to override (DANGEROUS)"
+            )
+
+        bl.write_firmware(firmware, progress=progress)
+        result["flashed"] = True
+        result["bytes"] = len(firmware)
+        return result

--- a/riden_server.py
+++ b/riden_server.py
@@ -4,7 +4,7 @@ awto-riden socket server — owns all serial/BLE access, multiplexes it over
 a Unix domain socket so that multiple clients (MCP, CLI, scripts) can share
 one PSU session.
 
-PARKED (see issue #7): development is CLI-first for now (ttu_cli.py talks to
+PARKED (see issue #7): development is CLI-first for now (awto_riden.py talks to
 RidenWorker directly, no daemon). This server is kept for a future
 multi-instrument device hub (Sork/Pulse/nScope), not the active path.
 

--- a/scripts/output_test.py
+++ b/scripts/output_test.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# output_test.py — write-path hardware test for RidenWorker, safe-state first.
+#
+# Safety model (mandatory for any write-path test on a live supply):
+#
+#   1. RECONNECT PER TEST. Every test stage opens its OWN fresh RidenWorker
+#      connection and closes it — nothing is shared, so a wedged handle in one
+#      stage cannot corrupt another.
+#
+#   2. SEPARATE-CONNECTION ZEROING (second stage). After each test, a DISTINCT
+#      connection is opened solely to drive the PSU to 0.0 V / 0.0 A. The
+#      zeroing never rides on the test's own connection — it is always its own
+#      second stage, so the safe state is reached through an independent path.
+#
+#   3. GLOBAL ERROR HANDLER. The whole run is wrapped so that ANY exception
+#      (including Ctrl-C) forces the same separate-connection 0.0 V / 0.0 A
+#      safe state before the error propagates. A failed or aborted test never
+#      leaves the supply energized.
+#
+# The supply is left at 0.0 V / 0.0 A with output OFF when the run ends, however
+# it ends. Complements scripts/transport_test.py (read-only).
+#
+# Usage:
+#   python3 scripts/output_test.py --port /dev/ttyUSB0 --address 1
+#   python3 scripts/output_test.py --simulate-error   # prove the global handler zeros
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from riden_daemon import RidenWorker
+
+# Safe state the supply is driven to between/after tests and on any error.
+SAFE_V = 0.0
+SAFE_I = 0.0
+
+# RD/RK firmware refreshes its Modbus registers once per scan cycle (~143 ms);
+# wait two cycles after a write before reading back so the setpoint has settled.
+SETTLE_S = 0.30
+
+
+def _connect(args) -> RidenWorker:
+    """Open a FRESH RidenWorker connection. Each test and each zeroing stage
+    calls this — connections are never reused across stages."""
+    w = RidenWorker(port=args.port, baud=args.baud, address=args.address)
+    w.open()
+    return w
+
+
+def safe_zero(args, reason: str = "") -> None:
+    """SECOND STAGE: open a separate connection and force 0.0 V / 0.0 A + output OFF.
+
+    Independent of any test connection. Best-effort and never raises — it is the
+    last line of defence, invoked after every test, by the global error handler,
+    and once more at the very end.
+    """
+    tag = f" ({reason})" if reason else ""
+    try:
+        w = _connect(args)
+        try:
+            w.set_voltage(SAFE_V)
+            w.set_current(SAFE_I)
+            w.set_output(False)
+            time.sleep(SETTLE_S)
+            s = w.status()
+            print(f"  safe-state{tag}: v_set={s['v_set']} V  i_set={s['i_set']} A  "
+                  f"output={'ON' if s['output'] else 'OFF'}")
+        finally:
+            w.close()
+    except Exception as exc:
+        # Never let the safety stage itself raise — report and move on.
+        print(f"  WARNING: safe-state{tag} could not be applied: {exc}", file=sys.stderr)
+
+
+def run_test(args, name: str, body) -> tuple[str, bool]:
+    """Run one test on its OWN fresh connection, then zero via a SEPARATE one.
+
+    *body* receives the open worker and returns True on pass. The test
+    connection is always closed before the separate zeroing stage runs.
+    """
+    print(f"[test] {name}")
+    w = _connect(args)                       # (1) reconnect per test
+    try:
+        ok = bool(body(w))
+    finally:
+        w.close()                            # close the test connection first ...
+    safe_zero(args, reason=f"after {name}")  # (2) ... then zero on a SEPARATE connection
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    return name, ok
+
+
+def run_all_tests(args) -> list[tuple[str, bool]]:
+    results: list[tuple[str, bool]] = []
+
+    def t_set_voltage(w) -> bool:
+        w.set_voltage(1.0)
+        time.sleep(SETTLE_S)
+        return abs(float(w.status()["v_set"]) - 1.0) < 0.05
+    results.append(run_test(args, "set_voltage 1.0 V", t_set_voltage))
+
+    def t_set_current(w) -> bool:
+        w.set_current(0.5)
+        time.sleep(SETTLE_S)
+        return abs(float(w.status()["i_set"]) - 0.5) < 0.05
+    results.append(run_test(args, "set_current 0.5 A", t_set_current))
+
+    def t_output_on(w) -> bool:
+        # Output is at 0.0 V from the prior zeroing stage, so this energizes
+        # nothing — it only exercises the output-enable write path.
+        w.set_output(True)
+        time.sleep(SETTLE_S)
+        return w.status()["output"] is True
+    results.append(run_test(args, "output on", t_output_on))
+
+    if args.simulate_error:
+        # Deliberately fail to prove the GLOBAL handler still forces safe state.
+        raise RuntimeError("simulated mid-test failure (--simulate-error)")
+
+    def t_output_off(w) -> bool:
+        w.set_output(False)
+        time.sleep(SETTLE_S)
+        return w.status()["output"] is False
+    results.append(run_test(args, "output off", t_output_off))
+
+    return results
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="RidenWorker write-path test (safe-state first)")
+    p.add_argument("--port", default="/dev/ttyUSB0")
+    p.add_argument("--baud", type=int, default=115200)
+    p.add_argument("--address", type=int, default=1)
+    p.add_argument("--simulate-error", action="store_true",
+                   help="raise mid-run to verify the global error handler zeros the PSU")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    results: list[tuple[str, bool]] = []
+    try:
+        results = run_all_tests(args)
+    except BaseException as exc:                       # GLOBAL error handler
+        print(f"GLOBAL ERROR ({type(exc).__name__}): {exc}", file=sys.stderr)
+        safe_zero(args, reason="global error handler")  # force safe state on ANY failure
+        raise
+    finally:
+        safe_zero(args, reason="final")                 # belt-and-braces: always safe at exit
+
+    ok = all(passed for _, passed in results)
+    print("ALL PASS" if ok else "SOME FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/plot_serial_comparison.py
+++ b/scripts/plot_serial_comparison.py
@@ -22,7 +22,7 @@ import numpy as np
 
 # ---------------------------------------------------------------------------
 # Reference data: RK6006 on /dev/ttyUSB0 USB-direct, 30 samples, 2026-05-02
-# Measured with: python3 ttu_cli.py --port /dev/ttyUSB0 profile-serial --count 30 --sleep-ms 150
+# Measured with: python3 awto_riden.py --port /dev/ttyUSB0 profile-serial --count 30 --sleep-ms 150
 # ---------------------------------------------------------------------------
 RK6006_REFERENCE = {
     "label": "RK6006\n(USB-direct, CH340)",

--- a/test_harness.py
+++ b/test_harness.py
@@ -22,14 +22,23 @@ Run:
 from __future__ import annotations
 
 import os
+import struct
 import subprocess
 import sys
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
 from protocol import make_err, make_ok
 from riden_daemon import RidenWorker, discover_devices
 from riden_transport import SerialTransport
+from riden_flash import (
+    RidenBootloader,
+    flash_firmware,
+    model_from_filename,
+    FlashError,
+    SUPPORTED_MODELS,
+)
 
 # Repo root — used as cwd for the CLI subprocess test. Derived from this
 # file's location so a rename of the checkout dir can't stale it again.
@@ -265,7 +274,7 @@ class TestCLI(unittest.TestCase):
     def test_cli_help(self) -> None:
         """CLI --help exits 0 and prints usage."""
         result = subprocess.run(
-            [sys.executable, "ttu_cli.py", "--help"],
+            [sys.executable, "awto_riden.py", "--help"],
             capture_output=True,
             text=True,
             cwd=REPO_ROOT,
@@ -432,6 +441,167 @@ class TestDiscovery(unittest.TestCase):
             "errors", "timed_out", "max_scan_s", "scan_ms", "skipped",
         ):
             self.assertIn(key, result, f"discover_devices response missing {key}")
+
+
+# ---------------------------------------------------------------------------
+# Layer 6 — Bootloader firmware loader (riden_flash), mocked serial
+# ---------------------------------------------------------------------------
+
+class _FakeBootSerial:
+    """Simulates a Riden unit's serial bootloader protocol for tests.
+
+    Responds to each written command by queueing the bytes a real unit would
+    return, so RidenBootloader's write/read cycles behave end-to-end without
+    hardware.
+    """
+
+    def __init__(self, *, in_bootloader=False, model=60066, fw_raw=109,
+                 serial_num=1036, chunk_ack=b"OK", upfirm_ready=b"upredy"):
+        self._boot = in_bootloader
+        self._model = model
+        self._fw = fw_raw
+        self._sn = serial_num
+        self._chunk_ack = chunk_ack
+        self._upfirm = upfirm_ready
+        self._rx = bytearray()
+        self.timeout = None
+        self.written = bytearray()
+        self.closed = False
+
+    def _info_block(self) -> bytes:
+        b = bytearray(b"inf")
+        b += struct.pack("<I", self._sn)     # serial LE32 -> res[3..6]
+        b += struct.pack("<H", self._model)  # model  LE16 -> res[7..8]
+        b += b"\x00\x00"                       # pad         -> res[9..10]
+        b += bytes([self._fw])                 # fw          -> res[11]
+        b += b"\x00"                           # pad         -> res[12]
+        return bytes(b)
+
+    def write(self, data):
+        self.written += data
+        d = bytes(data)
+        if d == b"queryd\r\n":
+            self._rx += b"boot" if self._boot else b"\x00\x00\x00\x00"
+        elif d == b"getinf\r\n":
+            self._rx += self._info_block()
+        elif d == b"upfirm\r\n":
+            self._rx += self._upfirm
+        elif len(d) == 8 and d[1] == 0x06:     # Modbus FC06 reboot frame
+            self._rx += b"\xfc"
+            self._boot = True
+        else:                                   # firmware chunk
+            self._rx += self._chunk_ack
+        return len(data)
+
+    def read(self, n):
+        out = bytes(self._rx[:n])
+        del self._rx[:n]
+        return out
+
+    def close(self):
+        self.closed = True
+
+
+class TestFlash(unittest.TestCase):
+
+    def test_model_from_filename(self):
+        self.assertEqual(model_from_filename("RD60066_V1.09.bin"), 60066)
+        self.assertEqual(model_from_filename("/path/RD60062_V1.32.bin"), 60062)
+        self.assertIsNone(model_from_filename("random.bin"))
+
+    def test_in_bootloader_detection(self):
+        bl = RidenBootloader("MOCK")
+        bl._ser = _FakeBootSerial(in_bootloader=True)
+        self.assertTrue(bl.in_bootloader())
+        bl._ser = _FakeBootSerial(in_bootloader=False)
+        self.assertFalse(bl.in_bootloader())
+
+    def test_enter_bootloader_reboots_via_modbus(self):
+        fake = _FakeBootSerial(in_bootloader=False)
+        bl = RidenBootloader("MOCK", address=1)
+        bl._ser = fake
+        with patch("riden_flash.time.sleep"):     # skip the 3 s reboot settle
+            bl.enter_bootloader()
+        # A Modbus FC06 reboot frame (func 0x06) must have been written.
+        self.assertIn(b"\x06", bytes(fake.written))
+        self.assertTrue(fake._boot)
+
+    def test_info_parsing(self):
+        bl = RidenBootloader("MOCK")
+        bl._ser = _FakeBootSerial(model=60066, fw_raw=109, serial_num=1036)
+        info = bl.info()
+        self.assertEqual(info["model"], 60066)
+        self.assertEqual(info["fw"], "v1.09")
+        self.assertEqual(info["serial"], "00001036")
+        self.assertTrue(info["supported"])
+
+    def test_write_firmware_chunks_and_progress(self):
+        fake = _FakeBootSerial(in_bootloader=True)
+        bl = RidenBootloader("MOCK")
+        bl._ser = fake
+        firmware = bytes(range(150))            # 150 bytes -> 64 + 64 + 22
+        seen = []
+        bl.write_firmware(firmware, progress=lambda d, t: seen.append((d, t)))
+        self.assertIn(b"upfirm\r\n", bytes(fake.written))
+        self.assertEqual(seen[-1], (150, 150))  # final progress = full image
+        self.assertEqual(len(seen), 3)          # three chunks
+
+    def test_write_firmware_rejected_chunk_raises(self):
+        bl = RidenBootloader("MOCK")
+        bl._ser = _FakeBootSerial(in_bootloader=True, chunk_ack=b"XX")
+        with self.assertRaises(FlashError):
+            bl.write_firmware(b"\x00" * 64)
+
+    def test_flash_firmware_refuses_without_confirm(self):
+        with patch("serial.Serial", return_value=_FakeBootSerial(in_bootloader=True)), \
+             patch("riden_flash.time.sleep"):
+            with tempfile.NamedTemporaryFile(suffix="RD60066.bin", delete=False) as f:
+                f.write(b"\x00" * 64)
+                path = f.name
+            try:
+                with self.assertRaises(FlashError):
+                    flash_firmware("MOCK", path, confirm=False)
+            finally:
+                os.unlink(path)
+
+    def test_flash_firmware_model_mismatch_refused(self):
+        # device model 60066, but firmware filename says 60241 -> refuse
+        with patch("serial.Serial", return_value=_FakeBootSerial(model=60066, in_bootloader=True)), \
+             patch("riden_flash.time.sleep"):
+            d = tempfile.mkdtemp()
+            path = os.path.join(d, "RD60241_V1.39.bin")
+            with open(path, "wb") as fh:
+                fh.write(b"\x00" * 64)
+            try:
+                with self.assertRaises(FlashError):
+                    flash_firmware("MOCK", path, confirm=True)
+            finally:
+                os.unlink(path)
+                os.rmdir(d)
+
+    def test_flash_firmware_happy_path(self):
+        with patch("serial.Serial", return_value=_FakeBootSerial(model=60066, in_bootloader=True)), \
+             patch("riden_flash.time.sleep"):
+            d = tempfile.mkdtemp()
+            path = os.path.join(d, "RD60066_V1.10.bin")
+            with open(path, "wb") as fh:
+                fh.write(b"\xaa" * 130)
+            try:
+                result = flash_firmware("MOCK", path, confirm=True)
+            finally:
+                os.unlink(path)
+                os.rmdir(d)
+        self.assertTrue(result["flashed"])
+        self.assertEqual(result["bytes"], 130)
+        self.assertEqual(result["model"], 60066)
+
+    def test_flash_firmware_no_file_reboots_only(self):
+        with patch("serial.Serial", return_value=_FakeBootSerial(model=60066, in_bootloader=False)), \
+             patch("riden_flash.time.sleep"):
+            result = flash_firmware("MOCK", None)
+        self.assertFalse(result["flashed"])
+        self.assertIsNone(result["bytes"])
+        self.assertEqual(result["model"], 60066)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Bundles four related changes (all MIT-preserving). Full suite: **29 tests passing** (14 + 5 discovery + 10 flash), no hardware required.

## 1. `firmware` CLI command
`RidenWorker.firmware()` already existed but wasn't wired to the CLI. Added `awto-riden firmware` → reports `type/id/serial/fw/transport`. (Verified live: RK6006, id 60066, fw 109.)

## 2. Bootloader firmware flasher (`riden_flash.py`) — **MIT, clean reimplementation**
Lets firmware be flashed from Linux without the vendor PC software. Implements the Riden serial **bootloader protocol** (`queryd`/`getinf`/`upfirm` text commands + 64-byte chunked transfer, plus `SYSTEM`←`REBOOT_MAGIC` to enter the bootloader — already documented in `riden_register.py`).

> **Licensing:** the upstream `tjko/riden-flashtool` is **AGPL-3.0** (repo `LICENSE`; its `flash-rd.py` header inconsistently says GPL-3.0). This repo is **MIT**, so **no code was copied** — `riden_flash.py` is an independent implementation of the publicly-observable protocol facts only. `ATTRIBUTION.md` updated to record it as a *protocol reference, no code used*. AGPL copyleft does not propagate.

Exposed as `awto-riden flash [firmware.bin]` (handled pre-connect like `discover`):
- **`--yes` required** — the command reboots the unit into the bootloader.
- Refuses on **unsupported model** or **firmware-file/model mismatch** unless `--force`.
- `RK6006` (60066) is in `SUPPORTED_MODELS`.
- **No hardware flashing was performed** — we have no RK6006 image locally; logic is covered by 10 mocked-serial unit tests.

## 3. `scripts/output_test.py` — safe-state-first write-path hardware test
Reconnect per stage; a **separate second-stage connection** drives the PSU to **0.0 V / 0.0 A / output OFF** after each test; a **global error handler** forces the same safe state on any failure (`--simulate-error` proves it).

## 4. Rename `ttu_cli.py` → `awto_riden.py`
The installed console command was *already* `awto-riden` (pyproject `awto-riden = "..."`); only the legacy module filename lagged. `git mv` + updated entry point, test-harness invocation, docs, and comments. (Module uses `_` since `awto-riden.py` isn't importable; the `awto-riden` command is unchanged.)

## Test
```
.venv/bin/python test_harness.py    # Ran 29 tests — OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</content>
