### PR TITLE
feat: bench tooling + single-source register map + generated docs (cleanup P1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,38 @@ Common commands:
 - `set-ocp`
 - `speed-test`
 - `info`
+- `firmware` — device identity (model/id/serial/fw)
+- `flash [firmware.bin]` — reboot to bootloader / flash firmware (requires `--yes`)
+- `discover` — find PSUs across serial ports/addresses
+- `register-scan` / `diff-scan` — read register space (read-only)
+
+## Bench tooling & generated docs
+
+Two consolidated entry points sit alongside the device CLI (`awto_riden.py`):
+
+- **`scripts/awto-riden-test.py`** — master **hardware** test + characterization runner.
+  Chains stages (`identify,status,write,measure,characterize`) with a guaranteed
+  safe-state teardown (0 V / 0 A / output OFF) between every stage and on any error.
+  ```bash
+  scripts/awto-riden-test.py --all --power-limit 60
+  scripts/awto-riden-test.py --chain measure,characterize --steps 12
+  ```
+- **`scripts/awto-riden-dev.py`** — **bench/analysis + docs** tool (no PSU output).
+  ```bash
+  scripts/awto-riden-dev.py gen-docs                 # regenerate generated docs (see below)
+  scripts/awto-riden-dev.py analyze-scan scan.json   # classify a register scan vs the map
+  ```
+
+**Generated docs.** The register map and the documentation figures are generated, not
+hand-edited. The single source of truth for the register map is **`register_map.py`**
+(built on the canonical `riden_register.py`). Regenerate everything with:
+
+```bash
+scripts/awto-riden-dev.py gen-docs            # docs/registers.md (+ waveform figures)
+```
+
+`docs/registers.md` carries a "GENERATED — do not edit by hand" header; edit
+`register_map.py` and re-run `gen-docs` instead.
 
 ## Architecture
 

--- a/docs/registers.md
+++ b/docs/registers.md
@@ -1,63 +1,29 @@
 # Riden RD60xx/RK60xx Register Map
 
-This page documents the register map currently used by this repo and tracks known vs unknown regions.
+> **GENERATED FILE — do not edit by hand.**
+> Regenerate with: `scripts/awto-riden-dev.py gen-docs`
+> Single source of truth: `register_map.py` (built on `riden_register.py`).
 
-Canonical code source:
-- `riden_register.py`
-
-Additional attribution and evidence:
-- Baldanos/rd6006 register map
-- ShayBox/Riden constants
-- rssdev10/riden-flashtool (CAL_COMMIT, reboot magic)
-- Live scan evidence: `docs/data/register_scan_20260503-011913Z.json`
-
-## Device/Firmware compatibility notes
-
-Do not assume every register/range is identical across RD and RK firmware.
-
-Observed in this repo:
-
-| Device | Firmware | Evidence | Notes |
-|---|---|---|---|
-| RD6024 (id 60241) | v1.39 (`fw_raw=139`) | MCP `rd_firmware`, `rd_status`, `rd_register_scan` on `/dev/ttyUSB1` | Extended bank and empirical clusters are verified on this target. |
-| RK6006 (id 60066) | v1.09 (`fw=109`) | Existing report artifacts under `docs/reports/rk6006-id60066-fw109/` | RK firmware may differ; treat RD6024-only empirical ranges as non-portable until scanned on RK. |
-
-Practical rule:
-- Registers in the upstream/common map (`0..119`, `256`) are generally reliable cross-model.
-- Empirical ranges (`182..195`, `208..239`) should be treated as firmware-specific until re-verified per device.
-
-Recommended verification workflow (existing interfaces only):
-
-```bash
-source .venv/bin/activate
-python3 awto_riden.py --port /dev/ttyUSBX --baud 115200 --address 1 register-scan --start 0 --end 260 --batch 50 --report-only
-python3 awto_riden.py --port /dev/ttyUSBX --baud 115200 --address 1 diff-scan --start 0 --end 260 --batch 50 --settle-ms 300 --unknown-only
-```
-
-If a unit does not answer at address 1, retry with its configured Modbus address.
-
-## Address-space coverage
-
-This project accounts for addresses `0..256` as follows.
+## Address-space coverage (0–256)
 
 | Range | Status | Notes |
 |---|---|---|
-| 0-20 | Known | Core identity, measurements, output state |
-| 21-31 | Unknown | Reserved/undocumented |
-| 32-41 | Known | Battery/temp/energy counters |
-| 42-47 | Unknown | Reserved/undocumented |
-| 48-53 | Known | RTC date/time |
+| 0–20 | Known | Core identity, measurements, output state |
+| 21–31 | Unknown | Reserved/undocumented |
+| 32–41 | Known | Battery/temp/energy counters |
+| 42–47 | Unknown | Reserved/undocumented |
+| 48–53 | Known | RTC date/time |
 | 54 | Known | Calibration commit register |
-| 55-62 | Known | Calibration trim registers |
-| 63-65 | Unknown | Reserved/undocumented |
-| 66-72 | Known | UI/options |
-| 73-79 | Unknown | Reserved/undocumented |
-| 80-119 | Known | Presets M0-M9 |
-| 120-181 | Unknown | Reserved/undocumented |
-| 182-195 | Empirical | Metadata/calibration mirror cluster on RD6024 fw109 |
-| 196-207 | Unknown | Reserved/undocumented |
-| 208-239 | Empirical | Extended presets M10-M17 (V/I/OVP/OCP) |
-| 240-255 | Unknown | Reserved/undocumented |
+| 55–62 | Known | Calibration trim registers |
+| 63–65 | Unknown | Reserved/undocumented |
+| 66–72 | Known | UI/options |
+| 73–79 | Unknown | Reserved/undocumented |
+| 80–119 | Known | Presets M0-M9 |
+| 120–181 | Unknown | Reserved/undocumented |
+| 182–195 | Empirical | Metadata/calibration mirror cluster on RD6024 fw109 |
+| 196–207 | Unknown | Reserved/undocumented |
+| 208–239 | Empirical | Extended presets M10-M17 (V/I/OVP/OCP) |
+| 240–255 | Unknown | Reserved/undocumented |
 | 256 | Known | System control (bootloader trigger) |
 
 ## Register details
@@ -101,7 +67,7 @@ This project accounts for addresses `0..256` as follows.
 | 51 | HOUR | RTC hour |
 | 52 | MINUTE | RTC minute |
 | 53 | SECOND | RTC second |
-| 54 | CAL_COMMIT | Write `0x1501` to commit calibration |
+| 54 | CAL_COMMIT | Write 0x1501 to commit calibration |
 | 55 | V_OUT_ZERO | Target voltage offset trim (DAC) |
 | 56 | V_OUT_SCALE | Target voltage scale trim (DAC) |
 | 57 | V_BACK_ZERO | Display voltage offset trim (ADC) |
@@ -117,48 +83,103 @@ This project accounts for addresses `0..256` as follows.
 | 70 | OPT_LOGO | Option: startup logo |
 | 71 | OPT_LANG | Option: language |
 | 72 | OPT_LIGHT | Option: display brightness |
-| 80-83 | M0_V..M0_OCP | Preset bank M0 |
-| 84-87 | M1_V..M1_OCP | Preset bank M1 |
-| 88-91 | M2_V..M2_OCP | Preset bank M2 |
-| 92-95 | M3_V..M3_OCP | Preset bank M3 |
-| 96-99 | M4_V..M4_OCP | Preset bank M4 |
-| 100-103 | M5_V..M5_OCP | Preset bank M5 |
-| 104-107 | M6_V..M6_OCP | Preset bank M6 |
-| 108-111 | M7_V..M7_OCP | Preset bank M7 |
-| 112-115 | M8_V..M8_OCP | Preset bank M8 |
-| 116-119 | M9_V..M9_OCP | Preset bank M9 |
-| 208-211 | M10_V..M10_OCP | Extended preset bank M10 (empirical) |
-| 212-215 | M11_V..M11_OCP | Extended preset bank M11 (empirical) |
-| 216-219 | M12_V..M12_OCP | Extended preset bank M12 (empirical) |
-| 220-223 | M13_V..M13_OCP | Extended preset bank M13 (empirical) |
-| 224-227 | M14_V..M14_OCP | Extended preset bank M14 (empirical) |
-| 228-231 | M15_V..M15_OCP | Extended preset bank M15 (empirical) |
-| 232-235 | M16_V..M16_OCP | Extended preset bank M16 (empirical) |
-| 236-239 | M17_V..M17_OCP | Extended preset bank M17 (empirical) |
-| 256 | SYSTEM | System control; write `0x1601` to enter bootloader |
+| 80 | M0_V | Preset M0 voltage setpoint |
+| 81 | M0_I | Preset M0 current setpoint |
+| 82 | M0_OVP | Preset M0 OVP threshold |
+| 83 | M0_OCP | Preset M0 OCP threshold |
+| 84 | M1_V | Preset M1 voltage setpoint |
+| 85 | M1_I | Preset M1 current setpoint |
+| 86 | M1_OVP | Preset M1 OVP threshold |
+| 87 | M1_OCP | Preset M1 OCP threshold |
+| 88 | M2_V | Preset M2 voltage setpoint |
+| 89 | M2_I | Preset M2 current setpoint |
+| 90 | M2_OVP | Preset M2 OVP threshold |
+| 91 | M2_OCP | Preset M2 OCP threshold |
+| 92 | M3_V | Preset M3 voltage setpoint |
+| 93 | M3_I | Preset M3 current setpoint |
+| 94 | M3_OVP | Preset M3 OVP threshold |
+| 95 | M3_OCP | Preset M3 OCP threshold |
+| 96 | M4_V | Preset M4 voltage setpoint |
+| 97 | M4_I | Preset M4 current setpoint |
+| 98 | M4_OVP | Preset M4 OVP threshold |
+| 99 | M4_OCP | Preset M4 OCP threshold |
+| 100 | M5_V | Preset M5 voltage setpoint |
+| 101 | M5_I | Preset M5 current setpoint |
+| 102 | M5_OVP | Preset M5 OVP threshold |
+| 103 | M5_OCP | Preset M5 OCP threshold |
+| 104 | M6_V | Preset M6 voltage setpoint |
+| 105 | M6_I | Preset M6 current setpoint |
+| 106 | M6_OVP | Preset M6 OVP threshold |
+| 107 | M6_OCP | Preset M6 OCP threshold |
+| 108 | M7_V | Preset M7 voltage setpoint |
+| 109 | M7_I | Preset M7 current setpoint |
+| 110 | M7_OVP | Preset M7 OVP threshold |
+| 111 | M7_OCP | Preset M7 OCP threshold |
+| 112 | M8_V | Preset M8 voltage setpoint |
+| 113 | M8_I | Preset M8 current setpoint |
+| 114 | M8_OVP | Preset M8 OVP threshold |
+| 115 | M8_OCP | Preset M8 OCP threshold |
+| 116 | M9_V | Preset M9 voltage setpoint |
+| 117 | M9_I | Preset M9 current setpoint |
+| 118 | M9_OVP | Preset M9 OVP threshold |
+| 119 | M9_OCP | Preset M9 OCP threshold |
+| 208 | M10_V | Preset M10 voltage setpoint |
+| 209 | M10_I | Preset M10 current setpoint |
+| 210 | M10_OVP | Preset M10 OVP threshold |
+| 211 | M10_OCP | Preset M10 OCP threshold |
+| 212 | M11_V | Preset M11 voltage setpoint |
+| 213 | M11_I | Preset M11 current setpoint |
+| 214 | M11_OVP | Preset M11 OVP threshold |
+| 215 | M11_OCP | Preset M11 OCP threshold |
+| 216 | M12_V | Preset M12 voltage setpoint |
+| 217 | M12_I | Preset M12 current setpoint |
+| 218 | M12_OVP | Preset M12 OVP threshold |
+| 219 | M12_OCP | Preset M12 OCP threshold |
+| 220 | M13_V | Preset M13 voltage setpoint |
+| 221 | M13_I | Preset M13 current setpoint |
+| 222 | M13_OVP | Preset M13 OVP threshold |
+| 223 | M13_OCP | Preset M13 OCP threshold |
+| 224 | M14_V | Preset M14 voltage setpoint |
+| 225 | M14_I | Preset M14 current setpoint |
+| 226 | M14_OVP | Preset M14 OVP threshold |
+| 227 | M14_OCP | Preset M14 OCP threshold |
+| 228 | M15_V | Preset M15 voltage setpoint |
+| 229 | M15_I | Preset M15 current setpoint |
+| 230 | M15_OVP | Preset M15 OVP threshold |
+| 231 | M15_OCP | Preset M15 OCP threshold |
+| 232 | M16_V | Preset M16 voltage setpoint |
+| 233 | M16_I | Preset M16 current setpoint |
+| 234 | M16_OVP | Preset M16 OVP threshold |
+| 235 | M16_OCP | Preset M16 OCP threshold |
+| 236 | M17_V | Preset M17 voltage setpoint |
+| 237 | M17_I | Preset M17 current setpoint |
+| 238 | M17_OVP | Preset M17 OVP threshold |
+| 239 | M17_OCP | Preset M17 OCP threshold |
+| 256 | SYSTEM | System control; write 0x1601 to enter bootloader |
 
-## Magic values
+## Magic command values
 
-| Value | Use |
-|---|---|
-| `0x1501` (5377) | Write to `CAL_COMMIT` (54) to persist calibration |
-| `0x1601` (5633) | Write to `SYSTEM` (256) to enter bootloader |
+| Value | Name | Use |
+|---|---|---|
+| `0x1501` (5377) | CAL_COMMIT_MAGIC | Write to `CAL_COMMIT` (54) to persist calibration |
+| `0x1601` (5633) | REBOOT_MAGIC | Write to `SYSTEM` (256) to enter bootloader |
 
-## Raw-to-engineering multipliers
+## Raw → engineering multipliers
 
-Scaling depends on model family.
-
-| Model family | V multiplier | I multiplier | P multiplier |
-|---|---:|---:|---:|
+| Model family | V | I | P |
+|---|--:|--:|--:|
 | RD6006 / RK6006 | 100 | 1000 | 100 |
 | RD6006P | 1000 | 10000 | 1000 |
 | RD6012 / RD6018 / RD6024 | 100 | 100 | 100 |
 
-Example:
-- Raw `V_OUT = 1200` with `V multiplier = 100` means `12.00 V`.
+e.g. raw `V_OUT = 1200` × (1/100) = **12.00 V**.
 
-## Notes
+## Evidence
 
-- `182-195` and `208-239` are based on empirical scans on RD6024 fw109 and should be treated as validated for that target, not universally guaranteed across all firmware.
-- Unknown ranges are intentionally listed to keep reverse-engineering scope explicit.
-- RK6006 uses different firmware lineage from RD6024 and may not expose all empirical RD ranges with identical semantics.
+- **RK6006 (id 60066, fw v1.09):** full read scan (0–260) shows the documented
+  map plus addrs **120–207 reading `0xFFFF` (unimplemented)** and **zero**
+  undocumented live registers. The RD6024 empirical banks (182–239) are NOT
+  present on RK firmware.
+- Sources: `riden_register.py`, Baldanos/rd6006, ShayBox/Riden,
+  rssdev10/tjko riden-flashtool (magic values). See `ATTRIBUTION.md`.
+

--- a/register_map.py
+++ b/register_map.py
@@ -1,0 +1,192 @@
+# register_map.py — single source of truth for the Riden register map (rich).
+#
+# Addresses and names come from riden_register.Register (canonical, copied
+# verbatim from ShayBox/Riden). THIS module is the one place to maintain the
+# human-facing map on top of that: per-register descriptions, the known/unknown
+# range classification, the command "magic" values, and the raw->engineering
+# multipliers. Both the dev analysis tool (awto-riden-dev.py) and the docs
+# generator read from here, so docs/registers.md is GENERATED, never hand-edited.
+
+from __future__ import annotations
+
+from riden_register import Register as R
+
+MAX_ADDR = 256
+
+# Per-register descriptions, keyed by the canonical names in riden_register.py.
+# Preset-bank descriptions (M0..M17) are generated, so they are not listed here.
+DESCRIPTIONS: dict[str, str] = {
+    "ID": "Device ID/model code",
+    "SN_H": "Serial number high word",
+    "SN_L": "Serial number low word",
+    "FW": "Firmware version code",
+    "INT_C_S": "Internal temperature sign (C)",
+    "INT_C": "Internal temperature value (C)",
+    "INT_F_S": "Internal temperature sign (F)",
+    "INT_F": "Internal temperature value (F)",
+    "V_SET": "Voltage setpoint raw",
+    "I_SET": "Current setpoint raw",
+    "V_OUT": "Output voltage raw",
+    "I_OUT": "Output current raw",
+    "AH": "Amp-hour counter raw",
+    "P_OUT": "Output power raw",
+    "V_IN": "Input voltage raw",
+    "KEYPAD": "Keypad lock state",
+    "OVP_OCP": "Protection state (none/OVP/OCP)",
+    "CV_CC": "Regulation mode (CV/CC)",
+    "OUTPUT": "Output enabled state",
+    "PRESET": "Active preset index",
+    "I_RANGE": "Current range selector (RD6012P)",
+    "BAT_MODE": "Battery mode",
+    "V_BAT": "Battery voltage",
+    "EXT_C_S": "External temperature sign (C)",
+    "EXT_C": "External temperature value (C)",
+    "EXT_F_S": "External temperature sign (F)",
+    "EXT_F": "External temperature value (F)",
+    "AH_H": "Amp-hour counter high word",
+    "AH_L": "Amp-hour counter low word",
+    "WH_H": "Watt-hour counter high word",
+    "WH_L": "Watt-hour counter low word",
+    "YEAR": "RTC year",
+    "MONTH": "RTC month",
+    "DAY": "RTC day",
+    "HOUR": "RTC hour",
+    "MINUTE": "RTC minute",
+    "SECOND": "RTC second",
+    "CAL_COMMIT": "Write 0x1501 to commit calibration",
+    "V_OUT_ZERO": "Target voltage offset trim (DAC)",
+    "V_OUT_SCALE": "Target voltage scale trim (DAC)",
+    "V_BACK_ZERO": "Display voltage offset trim (ADC)",
+    "V_BACK_SCALE": "Display voltage scale trim (ADC)",
+    "I_OUT_ZERO": "Target current offset trim (DAC)",
+    "I_OUT_SCALE": "Target current scale trim (DAC)",
+    "I_BACK_ZERO": "Display current offset trim (ADC)",
+    "I_BACK_SCALE": "Display current scale trim (ADC)",
+    "OPT_TAKE_OK": "Option: take OK behavior",
+    "OPT_TAKE_OUT": "Option: take output behavior",
+    "OPT_BOOT_POW": "Option: boot power state",
+    "OPT_BUZZ": "Option: buzzer",
+    "OPT_LOGO": "Option: startup logo",
+    "OPT_LANG": "Option: language",
+    "OPT_LIGHT": "Option: display brightness",
+    "SYSTEM": "System control; write 0x1601 to enter bootloader",
+}
+
+# Known/unknown/empirical coverage of the 0..256 address space.
+RANGES: list[tuple[int, int, str, str]] = [
+    (0, 20, "Known", "Core identity, measurements, output state"),
+    (21, 31, "Unknown", "Reserved/undocumented"),
+    (32, 41, "Known", "Battery/temp/energy counters"),
+    (42, 47, "Unknown", "Reserved/undocumented"),
+    (48, 53, "Known", "RTC date/time"),
+    (54, 54, "Known", "Calibration commit register"),
+    (55, 62, "Known", "Calibration trim registers"),
+    (63, 65, "Unknown", "Reserved/undocumented"),
+    (66, 72, "Known", "UI/options"),
+    (73, 79, "Unknown", "Reserved/undocumented"),
+    (80, 119, "Known", "Presets M0-M9"),
+    (120, 181, "Unknown", "Reserved/undocumented"),
+    (182, 195, "Empirical", "Metadata/calibration mirror cluster on RD6024 fw109"),
+    (196, 207, "Unknown", "Reserved/undocumented"),
+    (208, 239, "Empirical", "Extended presets M10-M17 (V/I/OVP/OCP)"),
+    (240, 255, "Unknown", "Reserved/undocumented"),
+    (256, 256, "Known", "System control (bootloader trigger)"),
+]
+
+# Raw -> engineering multipliers by model family.
+MULTIPLIERS: list[tuple[str, int, int, int]] = [
+    ("RD6006 / RK6006", 100, 1000, 100),
+    ("RD6006P", 1000, 10000, 1000),
+    ("RD6012 / RD6018 / RD6024", 100, 100, 100),
+]
+
+_PRESET_FIELD = {"V": "voltage setpoint", "I": "current setpoint",
+                 "OVP": "OVP threshold", "OCP": "OCP threshold"}
+
+
+def _preset_desc(name: str) -> str | None:
+    # Names like M0_V, M10_OCP -> "Preset M0 voltage setpoint".
+    if not name.startswith("M") or "_" not in name:
+        return None
+    bank, _, field = name.partition("_")
+    if bank[1:].isdigit() and field in _PRESET_FIELD:
+        return f"Preset {bank} {_PRESET_FIELD[field]}"
+    return None
+
+
+def registers() -> dict[int, dict]:
+    """Canonical address -> {name, desc}, sorted by address."""
+    out: dict[int, dict] = {}
+    for name, val in vars(R).items():
+        if name.startswith("_") or not isinstance(val, int):
+            continue
+        if val <= MAX_ADDR and not name.endswith("_MAGIC") and name != "BOOTLOADER":
+            desc = DESCRIPTIONS.get(name) or _preset_desc(name) or ""
+            out[val] = {"name": name, "desc": desc}
+    return dict(sorted(out.items()))
+
+
+def magic() -> dict[str, int]:
+    """Command 'magic' values (written to a register to trigger an action)."""
+    return {
+        name: val for name, val in vars(R).items()
+        if not name.startswith("_") and isinstance(val, int)
+        and (val > MAX_ADDR or name.endswith("_MAGIC") or name == "BOOTLOADER")
+    }
+
+
+def render_markdown() -> str:
+    """Render docs/registers.md entirely from this module. GENERATED — do not edit by hand."""
+    regs = registers()
+    lines: list[str] = []
+    lines.append("# Riden RD60xx/RK60xx Register Map")
+    lines.append("")
+    lines.append("> **GENERATED FILE — do not edit by hand.**")
+    lines.append("> Regenerate with: `scripts/awto-riden-dev.py gen-docs`")
+    lines.append("> Single source of truth: `register_map.py` (built on `riden_register.py`).")
+    lines.append("")
+    lines.append("## Address-space coverage (0–256)")
+    lines.append("")
+    lines.append("| Range | Status | Notes |")
+    lines.append("|---|---|---|")
+    for lo, hi, status, note in RANGES:
+        rng = f"{lo}" if lo == hi else f"{lo}–{hi}"
+        lines.append(f"| {rng} | {status} | {note} |")
+    lines.append("")
+    lines.append("## Register details")
+    lines.append("")
+    lines.append("| Addr | Name | Description |")
+    lines.append("|---|---|---|")
+    for addr, info in regs.items():
+        lines.append(f"| {addr} | {info['name']} | {info['desc']} |")
+    lines.append("")
+    lines.append("## Magic command values")
+    lines.append("")
+    lines.append("| Value | Name | Use |")
+    lines.append("|---|---|---|")
+    lines.append("| `0x1501` (5377) | CAL_COMMIT_MAGIC | Write to `CAL_COMMIT` (54) to persist calibration |")
+    lines.append("| `0x1601` (5633) | REBOOT_MAGIC | Write to `SYSTEM` (256) to enter bootloader |")
+    lines.append("")
+    lines.append("## Raw → engineering multipliers")
+    lines.append("")
+    lines.append("| Model family | V | I | P |")
+    lines.append("|---|--:|--:|--:|")
+    for fam, v, i, pw in MULTIPLIERS:
+        lines.append(f"| {fam} | {v} | {i} | {pw} |")
+    lines.append("")
+    lines.append("e.g. raw `V_OUT = 1200` × (1/100) = **12.00 V**.")
+    lines.append("")
+    lines.append("## Evidence")
+    lines.append("")
+    lines.append("- **RK6006 (id 60066, fw v1.09):** full read scan (0–260) shows the documented")
+    lines.append("  map plus addrs **120–207 reading `0xFFFF` (unimplemented)** and **zero**")
+    lines.append("  undocumented live registers. The RD6024 empirical banks (182–239) are NOT")
+    lines.append("  present on RK firmware.")
+    lines.append("- Sources: `riden_register.py`, Baldanos/rd6006, ShayBox/Riden,")
+    lines.append("  rssdev10/tjko riden-flashtool (magic values). See `ATTRIBUTION.md`.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    print(render_markdown())

--- a/scripts/awto-riden-dev.py
+++ b/scripts/awto-riden-dev.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# awto-riden-dev.py — bench/analysis + docs dev tool for the Riden project.
+#
+# Consolidates the loose analysis/plotting/BLE/doc helpers behind one entry point
+# (the "awto standard"). Nothing here drives the PSU's output — for hardware
+# tests/characterization use awto-riden-test.py.
+#
+# Everything is DETERMINISTIC CODE — no LLM/token cost. The register map has a
+# single in-code source of truth (register_map.py); docs that are generated from
+# code or captured data are (re)built by `gen-docs`, never hand-edited.
+#
+# Subcommands:
+#   gen-docs [--registers-only]            regenerate generated docs: register map
+#                                          (from register_map.py) + waveform figures
+#   analyze-scan <scan.json> [--map CFG]   classify a scan vs the map: known /
+#                                          unimplemented (0xFFFF) / real-value RE targets
+#   export-map [--out FILE]                dump the in-code register map -> JSON config
+#   plot {waveforms,serial,ble} [args...]  regenerate documentation figures
+#   ble  {profile,globe}        [args...]  BLE transport experiments
+#   report                      [args...]  (re)build docs/reports + index
+#
+# Usage:
+#   scripts/awto-riden-dev.py gen-docs
+#   scripts/awto-riden-dev.py analyze-scan tmp/regscan-rk6006.json
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
+sys.path.insert(0, REPO_ROOT)
+
+UNIMPLEMENTED = 0xFFFF  # registers that read all-ones are treated as not-present
+
+PLOT_SCRIPTS = {
+    "waveforms": "plot_waveforms.py",
+    "serial": "plot_serial_comparison.py",
+    "ble": "plot_ble_globe.py",
+}
+BLE_SCRIPTS = {
+    "profile": "ble_profile.py",
+    "globe": "ble_globe_turnon.py",
+}
+REPORT_SCRIPT = "report_pages.py"
+
+
+def _delegate(script: str, passthrough: list[str], optional: bool = False) -> int:
+    path = os.path.join(SCRIPTS_DIR, script)
+    if not os.path.exists(path):
+        msg = f"underlying script not found: {path}"
+        print(("(skip) " if optional else "") + msg, file=sys.stderr)
+        return 0 if optional else 1
+    return subprocess.call([sys.executable, path, *passthrough], cwd=REPO_ROOT)
+
+
+# --- register map (single in-code source = register_map.py) -----------------
+
+def _reg_names_from_code() -> dict[int, str]:
+    import register_map
+    return {addr: info["name"] for addr, info in register_map.registers().items()}
+
+
+def _reg_names_from_config(path: str) -> dict[int, str]:
+    if path.endswith(".toml"):
+        import tomllib
+        with open(path, "rb") as fh:
+            raw = tomllib.load(fh)
+    else:
+        with open(path) as fh:
+            raw = json.load(fh)
+    return {int(k): v for k, v in raw.get("registers", {}).items()}
+
+
+def export_map(out_path: str | None) -> int:
+    import register_map
+    regs = {str(a): i["name"] for a, i in register_map.registers().items()}
+    payload = {"registers": regs, "magic": register_map.magic(),
+               "_generated_from": "register_map.py (single source)"}
+    text = json.dumps(payload, indent=2)
+    if out_path:
+        with open(out_path, "w") as fh:
+            fh.write(text + "\n")
+        print(f"WROTE {out_path}  ({len(regs)} registers)", file=sys.stderr)
+    else:
+        print(text)
+    return 0
+
+
+def gen_docs(registers_only: bool) -> int:
+    """Regenerate everything that is generated from code or captured data."""
+    import register_map
+    out = os.path.join(REPO_ROOT, "docs", "registers.md")
+    with open(out, "w") as fh:
+        fh.write(register_map.render_markdown() + "\n")
+    print(f"WROTE docs/registers.md  ({len(register_map.registers())} registers)", file=sys.stderr)
+    if registers_only:
+        return 0
+    # Waveform figures: regenerate PNGs from existing JSONL (best-effort; needs no PSU).
+    print("regenerating waveform figures (best-effort)...", file=sys.stderr)
+    _delegate("regen_waveforms.py", [], optional=True)
+    return 0
+
+
+# --- scan analysis ----------------------------------------------------------
+
+def analyze_scan(path: str, as_json: bool, map_path: str | None) -> int:
+    """Classify a register-scan JSON against the in-code map (or a --map config)."""
+    try:
+        data = json.load(open(path))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"cannot read scan JSON {path}: {exc}", file=sys.stderr)
+        return 1
+
+    reg_names = _reg_names_from_config(map_path) if map_path else _reg_names_from_code()
+    src = map_path or "register_map.py (in-code single source)"
+
+    def known(r) -> bool:
+        return r["addr"] in reg_names
+
+    regs = data.get("registers", [])
+    known_live = [r for r in regs if known(r)]
+    unimpl = [r for r in regs if not known(r) and r.get("value") == UNIMPLEMENTED]
+    targets = [r for r in regs if not known(r) and r.get("value") not in (0, UNIMPLEMENTED)]
+
+    summary = {
+        "source": path,
+        "map": src,
+        "scanned": len(regs),
+        "known_live": len(known_live),
+        "unimplemented_0xffff": len(unimpl),
+        "unimplemented_addrs": sorted(r["addr"] for r in unimpl),
+        "re_targets": [
+            {"addr": r["addr"], "name": reg_names.get(r["addr"], "unknown"),
+             "hex": r["hex"], "value": r["value"]} for r in targets
+        ],
+        "re_target_count": len(targets),
+    }
+
+    if as_json:
+        print(json.dumps(summary, indent=2))
+        return 0
+
+    print(f"scan: {path}")
+    print(f"  map source              : {summary['map']}")
+    print(f"  scanned registers       : {summary['scanned']}")
+    print(f"  known/mapped (live)      : {summary['known_live']}")
+    print(f"  unimplemented (0xFFFF)   : {summary['unimplemented_0xffff']}  "
+          f"-> {summary['unimplemented_addrs']}")
+    print(f"  UNKNOWN with real values : {summary['re_target_count']}  (RE targets)")
+    for t in summary["re_targets"]:
+        print(f"      addr {t['addr']:>3}  {t['name']:<14} {t['hex']}  = {t['value']}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Riden bench/analysis + docs dev tool (no PSU output)")
+    sub = p.add_subparsers(dest="cmd", required=True, metavar="SUBCOMMAND")
+
+    sp = sub.add_parser("gen-docs", help="regenerate generated docs (register map + figures)")
+    sp.add_argument("--registers-only", action="store_true", help="only regenerate docs/registers.md")
+
+    sp = sub.add_parser("analyze-scan", help="classify a register-scan JSON vs the map")
+    sp.add_argument("scan_json", help="path to a register-scan --save-json file")
+    sp.add_argument("--map", default=None, help="register-map config (.json/.toml); default = register_map.py")
+    sp.add_argument("--json", action="store_true", help="emit the classification as JSON")
+
+    sp = sub.add_parser("export-map", help="dump the in-code register map to a JSON config")
+    sp.add_argument("--out", default=None, help="output path; stdout if omitted")
+
+    sp = sub.add_parser("plot", help="regenerate documentation figures")
+    sp.add_argument("which", choices=sorted(PLOT_SCRIPTS), help="figure set")
+
+    sp = sub.add_parser("ble", help="BLE transport experiments")
+    sp.add_argument("which", choices=sorted(BLE_SCRIPTS), help="BLE tool")
+
+    sub.add_parser("report", help="(re)build docs/reports + index")
+
+    args, passthrough = p.parse_known_args()
+
+    if args.cmd == "gen-docs":
+        return gen_docs(args.registers_only)
+    if args.cmd == "analyze-scan":
+        return analyze_scan(args.scan_json, args.json, args.map)
+    if args.cmd == "export-map":
+        return export_map(args.out)
+    if args.cmd == "plot":
+        return _delegate(PLOT_SCRIPTS[args.which], passthrough)
+    if args.cmd == "ble":
+        return _delegate(BLE_SCRIPTS[args.which], passthrough)
+    if args.cmd == "report":
+        return _delegate(REPORT_SCRIPT, passthrough)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/awto-riden-test.py
+++ b/scripts/awto-riden-test.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+# awto-riden-test.py — master HARDWARE test + characterization runner for Riden PSUs.
+#
+# Chains named test STAGES. Safety model (same contract as output_test.py):
+#   * Every stage runs on its OWN fresh RidenWorker connection (reconnect per stage).
+#   * A SEPARATE second-stage connection drives the PSU to a safe state
+#     (0.0 V / 0.0 A / output OFF) after every stage, at the very end, and from a
+#     GLOBAL error handler on ANY failure — the supply is never left energized.
+#
+# Stages:
+#   identify      read device identity (model / fw / serial)            [read-only]
+#   status        read live PSU state                                   [read-only]
+#   write         write-path checks: set V/I + output toggle, read-back [low power]
+#   measure       measure the connected load's resistance (low-V probe) [<~6 W]
+#   characterize  load-line sweep up to --power-limit, record V/I/P/R   [<= ceiling]
+#
+# Usage:
+#   scripts/awto-riden-test.py --all
+#   scripts/awto-riden-test.py --chain identify,status,measure,characterize
+#   scripts/awto-riden-test.py --chain characterize --power-limit 60 --steps 12
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from riden_daemon import RidenWorker
+
+# --- Device / safety limits -------------------------------------------------
+PSU_MAX_V = 60.0          # RK6006 ceiling
+PSU_MAX_I = 6.0
+V_MARGIN = 58.0           # stay just under the rails
+I_MARGIN = 5.5
+SAFE_V = 0.0
+SAFE_I = 0.0
+PSU_TEMP_ABORT_C = 80     # abort a sweep if the PSU's own internal temp gets this hot
+SETTLE_S = 0.30           # ~2x the ~143 ms RD/RK firmware scan cycle
+
+STAGES = ["identify", "status", "write", "measure", "characterize"]
+
+
+def _connect(args) -> RidenWorker:
+    w = RidenWorker(port=args.port, baud=args.baud, address=args.address)
+    w.open()
+    return w
+
+
+def safe_zero(args, reason: str = "") -> None:
+    """SECOND STAGE: fresh connection -> 0 V / 0 A / output OFF. Never raises."""
+    tag = f" ({reason})" if reason else ""
+    try:
+        w = _connect(args)
+        try:
+            w.set_voltage(SAFE_V)
+            w.set_current(SAFE_I)
+            w.set_output(False)
+            time.sleep(SETTLE_S)
+            s = w.status()
+            print(f"  safe-state{tag}: v_set={s['v_set']} i_set={s['i_set']} "
+                  f"output={'ON' if s['output'] else 'OFF'}", file=sys.stderr)
+        finally:
+            w.close()
+    except Exception as exc:
+        print(f"  WARNING: safe-state{tag} not applied: {exc}", file=sys.stderr)
+
+
+# --- Stages -----------------------------------------------------------------
+# Each stage: stage(args, ctx) -> dict. It opens its own worker, does its work,
+# closes; the runner then zeros via a SEPARATE connection.
+
+def stage_identify(args, ctx) -> dict:
+    w = _connect(args)
+    try:
+        return w.firmware()
+    finally:
+        w.close()
+
+
+def stage_status(args, ctx) -> dict:
+    w = _connect(args)
+    try:
+        return w.status()
+    finally:
+        w.close()
+
+
+def stage_write(args, ctx) -> dict:
+    """Low-power write-path checks with read-back."""
+    results = {}
+    w = _connect(args)
+    try:
+        w.set_voltage(1.0)
+        time.sleep(SETTLE_S)
+        results["set_voltage_1.0"] = abs(float(w.status()["v_set"]) - 1.0) < 0.05
+        w.set_current(0.5)
+        time.sleep(SETTLE_S)
+        results["set_current_0.5"] = abs(float(w.status()["i_set"]) - 0.5) < 0.05
+        w.set_output(True)
+        time.sleep(SETTLE_S)
+        results["output_on"] = w.status()["output"] is True
+        w.set_output(False)
+        time.sleep(SETTLE_S)
+        results["output_off"] = w.status()["output"] is False
+    finally:
+        w.close()
+    results["passed"] = all(results.values())
+    return results
+
+
+def stage_measure(args, ctx) -> dict:
+    """Measure the connected load's resistance with a low-voltage probe.
+
+    Probes at a couple of low setpoints (current-limited) and computes R = V/I.
+    Stores load_ohms in ctx for the characterize stage. Power stays < ~6 W.
+    """
+    points = []
+    w = _connect(args)
+    try:
+        w.set_current(3.0)          # limit during probe
+        w.set_output(True)
+        for v in (1.5, 3.0):
+            w.set_voltage(v)
+            time.sleep(SETTLE_S * 2)  # let it settle before reading current
+            s = w.status()
+            i_out = float(s["i_out"])
+            v_out = float(s["v_out"])
+            r = (v_out / i_out) if i_out > 0.001 else None
+            points.append({"v_out": v_out, "i_out": i_out, "p_out": float(s["p_out"]),
+                           "r_ohms": round(r, 3) if r else None})
+        w.set_output(False)
+    finally:
+        w.close()
+    rs = [p["r_ohms"] for p in points if p["r_ohms"]]
+    load_ohms = round(sum(rs) / len(rs), 3) if rs else None
+    ctx["load_ohms"] = load_ohms
+    return {"points": points, "load_ohms": load_ohms,
+            "note": "no current drawn — is a load connected?" if not load_ohms else None}
+
+
+def stage_characterize(args, ctx) -> dict:
+    """Sweep the load line from 0 up to the power ceiling; record V/I/P/R."""
+    r = ctx.get("load_ohms")
+    if not r:
+        raise RuntimeError("characterize needs a measured load_ohms — run 'measure' first")
+    if not (0.3 <= r <= 1000):
+        raise RuntimeError(f"measured load {r} ohms outside sane range; aborting")
+
+    p_limit = float(args.power_limit)
+    # Largest V that keeps V^2/R <= p_limit, also under the PSU rails / current.
+    v_by_power = (p_limit * r) ** 0.5
+    v_by_current = I_MARGIN * r
+    v_max = min(v_by_power, v_by_current, V_MARGIN)
+    i_max = v_max / r
+    i_limit = min(i_max * 1.2, I_MARGIN + 0.3)   # keep supply in CV across the sweep
+
+    print(f"  load={r}ohm  ceiling={p_limit}W  -> V_max={v_max:.2f}V "
+          f"I_max={i_max:.3f}A  ({v_max * i_max:.1f}W)", file=sys.stderr)
+
+    steps = max(2, int(args.steps))
+    dwell = float(args.dwell)
+    sweep = []
+    w = _connect(args)
+    try:
+        w.set_voltage(0.0)
+        w.set_current(round(i_limit, 3))
+        w.set_output(True)
+        for k in range(1, steps + 1):
+            v_set = round(v_max * k / steps, 3)
+            w.set_voltage(v_set)
+            time.sleep(dwell)
+            s = w.status()
+            v_out, i_out = float(s["v_out"]), float(s["i_out"])
+            p_out = float(s["p_out"])
+            temp = s.get("temp_c")
+            r_calc = round(v_out / i_out, 3) if i_out > 0.001 else None
+            sweep.append({"v_set": v_set, "v_out": v_out, "i_out": i_out,
+                          "p_out": p_out, "r_ohms": r_calc, "temp_c": temp})
+            print(f"    {v_set:5.2f}V -> {v_out:5.2f}V {i_out:5.3f}A "
+                  f"{p_out:5.2f}W  R={r_calc}  T={temp}C", file=sys.stderr)
+            if temp is not None and temp >= PSU_TEMP_ABORT_C:
+                print("    PSU temp abort!", file=sys.stderr)
+                break
+        w.set_voltage(0.0)
+        w.set_output(False)
+    finally:
+        w.close()
+
+    p_peak = max((p["p_out"] for p in sweep), default=0.0)
+    r_vals = [p["r_ohms"] for p in sweep if p["r_ohms"]]
+    return {
+        "load_ohms_measured": r,
+        "power_ceiling_w": p_limit,
+        "v_max": round(v_max, 3),
+        "i_limit": round(i_limit, 3),
+        "steps": len(sweep),
+        "peak_power_w": round(p_peak, 2),
+        "r_ohms_mean_under_load": round(sum(r_vals) / len(r_vals), 3) if r_vals else None,
+        "sweep": sweep,
+    }
+
+
+STAGE_FUNCS = {
+    "identify": stage_identify,
+    "status": stage_status,
+    "write": stage_write,
+    "measure": stage_measure,
+    "characterize": stage_characterize,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Riden master hardware test + characterization runner")
+    p.add_argument("--port", default="/dev/ttyUSB0")
+    p.add_argument("--baud", type=int, default=115200)
+    p.add_argument("--address", type=int, default=1)
+    p.add_argument("--all", action="store_true", help="run every stage in order")
+    p.add_argument("--chain", default="",
+                   help=f"comma-separated stages to run, in order (of: {','.join(STAGES)})")
+    p.add_argument("--power-limit", type=float, default=60.0,
+                   help="characterize power ceiling in watts (default 60 = 120%% of a 50 W load)")
+    p.add_argument("--steps", type=int, default=12, help="characterize sweep steps (default 12)")
+    p.add_argument("--dwell", type=float, default=0.4,
+                   help="seconds to dwell at each characterize step (default 0.4)")
+    p.add_argument("--out", default=None, help="write the full JSON summary to this path")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.all:
+        chain = list(STAGES)
+    else:
+        chain = [s.strip() for s in args.chain.split(",") if s.strip()]
+    if not chain:
+        print("nothing to run: pass --all or --chain <stages>", file=sys.stderr)
+        return 2
+    unknown = [s for s in chain if s not in STAGE_FUNCS]
+    if unknown:
+        print(f"unknown stage(s): {unknown}; valid: {STAGES}", file=sys.stderr)
+        return 2
+
+    ctx: dict = {}
+    report: dict = {"chain": chain, "stages": {}}
+    try:
+        for name in chain:
+            print(f"[stage] {name}", file=sys.stderr)
+            report["stages"][name] = STAGE_FUNCS[name](args, ctx)
+            safe_zero(args, reason=f"after {name}")   # separate-connection teardown
+    except BaseException as exc:
+        print(f"GLOBAL ERROR ({type(exc).__name__}): {exc}", file=sys.stderr)
+        safe_zero(args, reason="global error handler")
+        report["error"] = f"{type(exc).__name__}: {exc}"
+        _emit(report, args)
+        return 1
+    finally:
+        safe_zero(args, reason="final")
+
+    _emit(report, args)
+    return 0
+
+
+def _emit(report: dict, args) -> None:
+    text = json.dumps(report, indent=2)
+    print(text)
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(text + "\n")
+        print(f"WROTE {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Phase 1 of the pre-publish cleanup: consolidated bench tooling + a single-source register map + generated docs.

## What's added
- **`scripts/awto-riden-test.py`** — master **hardware** test/characterization runner. Chained stages (`identify,status,write,measure,characterize`) each on a fresh connection, with a guaranteed **safe-state teardown** (0 V / 0 A / output OFF) between every stage, at the end, and from a **global error handler** on any failure. The `characterize` stage auto-measures the load and sweeps a load line to a power ceiling, respecting the 60 V / 6 A rails. **Validated on real hardware:** RK6006 + 4.73 Ω, swept to 50.7 W, PSU steady at 35 °C.
- **`scripts/awto-riden-dev.py`** — **bench/analysis + docs** tool (no PSU output): `gen-docs`, `analyze-scan`, `export-map`, + `plot`/`ble`/`report` wrappers. Deterministic code, no per-run LLM cost.
- **`register_map.py`** — **single in-code source of truth** for the register map (names from the canonical `riden_register.py` + descriptions/ranges/magic). `analyze-scan` defaults to it, so there's **no separate config file** to keep in sync.

## Generated docs
- **`docs/registers.md` is now GENERATED** (header says so) from `register_map.py` via `awto-riden-dev.py gen-docs`.
- `gen-docs` also regenerates the waveform figures from the committed `docs/data/*.jsonl` capture fixtures — verified **10/10 PNGs regenerate offline, no hardware**.
- README documents the bench tooling + the regenerate-docs workflow.

## Evidence captured
RK6006 fw1.09 full read-scan: documented map + addrs **120–207 = `0xFFFF` (unimplemented)** + **zero undocumented live registers** (RD6024 empirical banks 182–239 absent on RK firmware).

Part of a multi-PR cleanup; follow-ups: full script rename/dedup, MCP fix, root-dir cleanup, gh-issue tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
